### PR TITLE
Renaming docker containers names to contain CEE so they don't conflic…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/service/docker/common-object-store-1.env
+++ b/service/docker/common-object-store-1.env
@@ -4,7 +4,7 @@ URI_HOST=localhost:8081
 REPLICATION_ENABLED=true
 
 DB_HOST=postgres
-DB_PORT=5432
+DB_PORT=5435
 DB_USER=postgres
 DB_PASS=password1
 DB_PASSWORD=password1

--- a/service/docker/common-object-store-2.env
+++ b/service/docker/common-object-store-2.env
@@ -4,7 +4,7 @@ URI_HOST=localhost:8082
 REPLICATION_ENABLED=true
 
 DB_HOST=postgres
-DB_PORT=5432
+DB_PORT=5435
 DB_USER=postgres
 DB_PASS=password1
 DB_PASSWORD=password1

--- a/service/docker/dependencies.yaml
+++ b/service/docker/dependencies.yaml
@@ -2,75 +2,74 @@ version: '3.5'
 
 services:
 
-  postgres:
-    image: postgres:13
-    container_name: postgres
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password1
-    ports:
-      - 5432:5432
-    volumes:
-      - ./db-init:/docker-entrypoint-initdb.d/
-    healthcheck:
-      test: [ CMD-SHELL, pg_isready -U postgres ]
-      interval: 5s
-      timeout: 10s
-      retries: 5
+    postgres:
+        image: postgres:13
+        container_name: postgres-cee
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=password1
+        ports:
+            - 5435:5435
+        volumes:
+            - ./db-init:/docker-entrypoint-initdb.d/
+        healthcheck:
+            test: [ CMD-SHELL, pg_isready -U postgres ]
+            interval: 5s
+            timeout: 10s
+            retries: 5
 
-  object-store-1:
-    image: ghcr.io/provenance-io/object-store:0.7.0
-    container_name: object-store-1
-    depends_on:
-      - postgres
-    env_file:
-      - ./common-object-store-1.env
-    ports:
-      - 5001:8081
-    volumes:
-        - ./object_store_1:/mnt/data
+    object-store-1:
+        image: ghcr.io/provenance-io/object-store:0.7.0
+        container_name: object-store-1-cee
+        depends_on:
+            - postgres-cee
+        env_file:
+            - ./common-object-store-1.env
+        ports:
+            - 5001:8081
+        volumes:
+            - ./object_store_1:/mnt/data
 
-  object-store-2:
-    image: ghcr.io/provenance-io/object-store:0.7.0
-    container_name: object-store-2
-    depends_on:
-      - postgres
-    env_file:
-      - ./common-object-store-2.env
-    ports:
-      - 5002:8082
-    volumes:
-        - ./object_store-2:/mnt/data
+    object-store-2:
+        image: ghcr.io/provenance-io/object-store:0.7.0
+        container_name: object-store-2-cee
+        depends_on:
+            - postgres-cee
+        env_file:
+            - ./common-object-store-2.env
+        ports:
+            - 5002:8082
+        volumes:
+            - ./object_store-2:/mnt/data
 
-  provenance:
-    image: provenanceio/provenance:v1.8.0-rc9
-    container_name: provenance
-    command: bash -c "cp -rn /home/provenance_seed/* /home/provenance && /usr/bin/provenanced -t --home /home/provenance start"
-    ports:
-      - 1317:1317
-      - 9090:9090
-      - 26657:26657
-    volumes:
-      - ./prov-init:/home/provenance_seed:ro
-      - provenance:/home/provenance
+    provenance:
+        image: provenanceio/provenance:v1.8.0-rc9
+        container_name: provenance-cee
+        command: bash -c "cp -rn /home/provenance_seed/* /home/provenance && /usr/bin/provenanced -t --home /home/provenance start"
+        ports:
+            - 1317:1317
+            - 9090:9090
+            - 26657:26657
+        volumes:
+            - ./prov-init:/home/provenance_seed:ro
+            - provenance:/home/provenance
 
-  vault:
-      image: vault:latest
-      container_name: vault
-      ports:
-          - "8200:8200"
-      restart: always
-      volumes:
-          - ./volumes/logs:/vault/logs
-          - ./volumes/file:/vault/file
-          - ./volumes/config:/vault/config
-      cap_add:
-          - IPC_LOCK
-      entrypoint: vault server -config=/vault/config/vault.json
+    vault:
+        image: vault:latest
+        container_name: vault-cee
+        ports:
+            - "8200:8200"
+        restart: always
+        volumes:
+            - ./volumes/logs:/vault/logs
+            - ./volumes/file:/vault/file
+            - ./volumes/config:/vault/config
+        cap_add:
+            - IPC_LOCK
+        entrypoint: vault server -config=/vault/config/vault.json
 
 volumes:
-  postgres:
-  object-store-1:
-  object-store-2:
-  provenance:
-  wallet:
+    object-store-1:
+    object-store-2:
+    provenance:
+    wallet:


### PR DESCRIPTION
Renaming docker containers names to contain CEE so they don't conflict with other services having containers named the same.   Changed the port Postgres running.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
