### PR TITLE
Correct names in dockerfile to specify postgres pod and not postgres-cee

### DIFF
--- a/service/docker/Dockerfile
+++ b/service/docker/Dockerfile
@@ -35,6 +35,6 @@ FROM openjdk:11-jre
 COPY --from=build /app/service/build/libs/*.jar /service.jar
 ADD service/docker/service-configure /configure
 
-EXPOSE 8080/tcp
+EXPOSE 8085/tcp
 
 ENTRYPOINT ./docker-entrypoint.sh /p8e-cee-api.jar

--- a/service/docker/dependencies.yaml
+++ b/service/docker/dependencies.yaml
@@ -22,7 +22,7 @@ services:
         image: ghcr.io/provenance-io/object-store:0.7.0
         container_name: object-store-1-cee
         depends_on:
-            - postgres-cee
+            - postgres
         env_file:
             - ./common-object-store-1.env
         ports:
@@ -34,7 +34,7 @@ services:
         image: ghcr.io/provenance-io/object-store:0.7.0
         container_name: object-store-2-cee
         depends_on:
-            - postgres-cee
+            - postgres
         env_file:
             - ./common-object-store-2.env
         ports:

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Spring boot server settings
-server.port=8080
+server.port=8085
 server.servlet.context-path=/p8e-cee-api
 # Increase header size to allow identity cookie spam
 server.max-http-header-size=48000


### PR DESCRIPTION
Correct names in dockerfile to specify postgres pod and not postgres-cee.
Change UI port to 8085 so users can run this without conflicting with other services running on 8080.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
