### PR TITLE
Add Convenience Method for Publishing p8e Contracts Locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,19 @@ Then, run the service - either via an Intellij run configuration or via the comm
 ```
 ./gradlew bootRun
 ```
+
+## Publishing p8e Contracts Locally
+
+As a convenience, you can publish contracts from another repository without leaving this project in the command line.
+
+```
+./dc.sh -p <path to contracts repository> publish
+```
+
+For example:
+
+```
+./dc.sh -p ../../provenance-io/loan-package-contracts publish
+```
+
+Note: This convenience method uses preset environment variables found in `/service/docker/bootstrap.env` and assumes the address used to sign the transactions associated with publishing the contracts is listed in the genesis block (`/service/docker/prov-init/config/genesis.json`).

--- a/dc.sh
+++ b/dc.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+while getopts 'p:' OPTION; do
+  case "$OPTION" in
+    p)
+      PATH_TO_CONTRACTS="$OPTARG"
+      echo "Path to contracts you wish to publish: $OPTARG"
+      ;;
+    ?)
+      echo "script usage: $(basename \$0) [-p <path to p8e contracts directory>]" >&2
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
 function up {
   #config vault
   sh service/docker/vault/config.sh
@@ -26,7 +40,26 @@ function up {
    0A2100F5FE00731E3BC71F22CF054712A7C1F9A610848FC04BA81E6822D82D82C3562E \
    "jealous bright oyster fluid guide talent crystal minor modify broken stove spoon pen thank action smart enemy chunk ladder soon focus recall elite pulp"
 
+   source ./service/docker/bootstrap.env
+
   docker ps -a
+}
+
+function publish() {
+    if [ -z ${PATH_TO_CONTRACTS+x} ]; then
+        echo "Provide a valid path to the contracts directory you wish to publish using the -p argument."
+        exit
+    fi
+
+    export FULL_PATH=$(realpath $PATH_TO_CONTRACTS)
+
+    if [[ -d "$FULL_PATH" ]]; then
+        pushd $PATH_TO_CONTRACTS > /dev/null
+        ./gradlew p8eClean p8eBootstrap --info
+        popd > /dev/null
+    else
+        echo "Invalid path. Provide a valid path to the contracts directory you wish to publish."
+    fi
 }
 
 function down {

--- a/dc.sh
+++ b/dc.sh
@@ -40,8 +40,6 @@ function up {
    0A2100F5FE00731E3BC71F22CF054712A7C1F9A610848FC04BA81E6822D82D82C3562E \
    "jealous bright oyster fluid guide talent crystal minor modify broken stove spoon pen thank action smart enemy chunk ladder soon focus recall elite pulp"
 
-   source ./service/docker/bootstrap.env
-
   docker ps -a
 }
 
@@ -51,6 +49,7 @@ function publish() {
         exit
     fi
 
+   source ./service/docker/bootstrap.env
     export FULL_PATH=$(realpath $PATH_TO_CONTRACTS)
 
     if [[ -d "$FULL_PATH" ]]; then

--- a/service/docker/bootstrap.env
+++ b/service/docker/bootstrap.env
@@ -1,16 +1,8 @@
-# Store three mnemonics and their corresponding private keys that can be used for provenance transactions and contract execution
+# Export a mnemonic, private key, and address that can be used for provenance transactions and contract execution
 
 export CHAINCODE_MNEMONIC_1="stable payment cliff fault abuse clinic bus belt film then forward world goose bring picnic rich special brush basic lamp window coral worry change"
 export PRIVATE_KEY_1="0A2100EF4A9391903BFE252CB240DA6695BC5F680A74A8E16BEBA003833DFE9B18C147"
 export ADDRESS_1="tp1hslffrztjp399d86a25fh2khg0c6je3achzhyj"
-
-export CHAINCODE_MNEMONIC_2="present pulse retreat vault snap buyer purse lift casual horse canal silent quick arrest wedding win slide cool bicycle pride display unhappy assume inside"
-export PRIVATE_KEY_2="0A2100CBEDAA6241122CB6B5BD2A3E1FFDD8694C0AEC16E80A0CC72B6256C56090F6FA"
-export ADDRESS_2="tp196g09ugqd0rhkqgu4cnd97e65akeq9dmhttc25"
-
-export CHAINCODE_MNEMONIC_3="genuine kitten liar plunge swim host way stove space room boring interest rose artist into marine mushroom minimum tip unfair nose plunge nest glory"
-export PRIVATE_KEY_3="0A21009B6CFD2525DD7EA500A3F2665047319A3D2A3F1D62177D686DF98713D8E52BDB"
-export ADDRESS_3="tp1xtfgv7djverfm08v4qcua4ga8gl3xvpx426ngx"
 
 # p8e contract bootstrapping - signing and encryption keys are the same and match the private key above
 
@@ -19,5 +11,3 @@ export ENCRYPTION_PRIVATE_KEY=$PRIVATE_KEY_1
 export OS_GRPC_URL="grpc://localhost:5001"
 export PROVENANCE_GRPC_URL="grpc://localhost:9090"
 export CHAIN_ID="chain-local"
-
-# Note: added identity #1 to /prov-init/config/genesis.json

--- a/service/docker/bootstrap.env
+++ b/service/docker/bootstrap.env
@@ -1,0 +1,23 @@
+# Store three mnemonics and their corresponding private keys that can be used for provenance transactions and contract execution
+
+export CHAINCODE_MNEMONIC_1="stable payment cliff fault abuse clinic bus belt film then forward world goose bring picnic rich special brush basic lamp window coral worry change"
+export PRIVATE_KEY_1="0A2100EF4A9391903BFE252CB240DA6695BC5F680A74A8E16BEBA003833DFE9B18C147"
+export ADDRESS_1="tp1hslffrztjp399d86a25fh2khg0c6je3achzhyj"
+
+export CHAINCODE_MNEMONIC_2="present pulse retreat vault snap buyer purse lift casual horse canal silent quick arrest wedding win slide cool bicycle pride display unhappy assume inside"
+export PRIVATE_KEY_2="0A2100CBEDAA6241122CB6B5BD2A3E1FFDD8694C0AEC16E80A0CC72B6256C56090F6FA"
+export ADDRESS_2="tp196g09ugqd0rhkqgu4cnd97e65akeq9dmhttc25"
+
+export CHAINCODE_MNEMONIC_3="genuine kitten liar plunge swim host way stove space room boring interest rose artist into marine mushroom minimum tip unfair nose plunge nest glory"
+export PRIVATE_KEY_3="0A21009B6CFD2525DD7EA500A3F2665047319A3D2A3F1D62177D686DF98713D8E52BDB"
+export ADDRESS_3="tp1xtfgv7djverfm08v4qcua4ga8gl3xvpx426ngx"
+
+# p8e contract bootstrapping - signing and encryption keys are the same and match the private key above
+
+export SIGNING_PRIVATE_KEY=$PRIVATE_KEY_1
+export ENCRYPTION_PRIVATE_KEY=$PRIVATE_KEY_1
+export OS_GRPC_URL="grpc://localhost:5001"
+export PROVENANCE_GRPC_URL="grpc://localhost:9090"
+export CHAIN_ID="chain-local"
+
+# Note: added identity #1 to /prov-init/config/genesis.json

--- a/service/docker/dependencies.yaml
+++ b/service/docker/dependencies.yaml
@@ -85,7 +85,6 @@ volumes:
     provenance:
     object-store-1:
     object-store-2:
-#    wallet:
 
 networks:
   p8e-network:

--- a/service/docker/prov-init/config/genesis.json
+++ b/service/docker/prov-init/config/genesis.json
@@ -87,6 +87,13 @@
           "sequence": "0"
         },
         {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "tp1hslffrztjp399d86a25fh2khg0c6je3achzhyj",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
           "@type": "/provenance.marker.v1.MarkerAccount",
           "base_account": {
             "address": "tp1pr93cqdh4kfnmrknhwa87a5qrwxw9k3dhkszp0",
@@ -169,6 +176,15 @@
         },
         {
           "address": "tp1c87ujqlc7wvstate9qcfu7tglesy3m7tnfwfrm",
+          "coins": [
+            {
+              "denom": "nhash",
+              "amount": "12500000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "tp1hslffrztjp399d86a25fh2khg0c6je3achzhyj",
           "coins": [
             {
               "denom": "nhash",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adding ability to publish p8e contract locally from this repository using one line:
```
./dc.sh -p <path to contracts repository> publish
```
Easily combined with `bounce` command to reset local environment. For example:
```
./dc.sh bounce
./dc.sh -p ../../provenance-io/loan-package-contracts publish
```
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
