### PR TITLE
Find record classes by parsing classifier string instead of type string

### DIFF
--- a/service/src/main/kotlin/io/provenance/onboarding/domain/usecase/cee/execute/ExecuteContract.kt
+++ b/service/src/main/kotlin/io/provenance/onboarding/domain/usecase/cee/execute/ExecuteContract.kt
@@ -23,6 +23,7 @@ import io.provenance.scope.sdk.SignedResult
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import java.util.Base64
+import kotlin.reflect.KType
 import kotlin.reflect.full.functions
 
 private val log = KotlinLogging.logger { }
@@ -77,7 +78,7 @@ class ExecuteContract(
             contract.kotlin.functions.forEach { func ->
                 func.parameters.forEach { param ->
                     (param.annotations.firstOrNull { it is Input } as? Input)?.let { input ->
-                        val parameterClass = Class.forName(param.type.toString())
+                        val parameterClass = Class.forName(param.type.toClassNameString())
                         val recordToParse = records.getOrDefault(input.name, null)
                             ?: throw IllegalStateException("Contract required input record with name ${input.name} but none was found!")
                         val record = contractParser.parseInput(recordToParse, parameterClass)
@@ -92,4 +93,6 @@ class ExecuteContract(
 
         return contractRecords
     }
+
+    private fun KType?.toClassNameString(): String? = this?.classifier?.toString()?.drop("class ".length)
 }


### PR DESCRIPTION
### Context
The contract execution usecase currently fails for classes that are being imported in Kotlin code as
```
import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
```
because
> JRE uses `.` as package separators and `$` for enclosing classes such that  `tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData` does not exist (ie no such package path actually exists) [but] `tech.figure.servicing.v1beta1.LoanStateOuterClass$ServicingData` does exist.

Ideally, the [protobuf definition files](https://github.com/provenance-io/metadata-asset-model/blob/d2c0ca92b9245ee2cacdf53aad9e664c91c70bca/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto) would be specifying
```
option java_multiple_files = true;
```
but doing so now would break existing imports. So instead, let's make the API more robust by being able to correctly find any nested classes.
### Changes
- Change the `ExecuteContract` usecase from stringifying a function parameter `KType` to stringifying the `KType`'s `KClassifier` and then extracting just the classifier from the resulting string of the form
  ```
  class tech.figure.servicing.v1beta1.LoanStateOuterClass$ServicingData
  ```
  which is not pretty but should be good enough for the indefinite future