### PR TITLE
Adding participants to audience keys

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContract.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContract.kt
@@ -17,12 +17,9 @@ import io.provenance.api.domain.usecase.common.originator.EntityManager
 import io.provenance.api.domain.usecase.common.originator.models.KeyManagementConfigWrapper
 import io.provenance.api.domain.usecase.provenance.account.GetSigner
 import io.provenance.api.domain.usecase.provenance.account.models.GetSignerRequest
-import io.provenance.api.frameworks.config.ProvenanceProperties
 import io.provenance.api.frameworks.provenance.SingleTx
-import io.provenance.metadata.v1.MsgAddScopeDataAccessRequest
 import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.spec.P8eContract
-import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.encryption.util.toJavaPublicKey
 import io.provenance.scope.sdk.FragmentResult
 import io.provenance.scope.sdk.SignedResult
@@ -42,7 +39,6 @@ class ExecuteContract(
     private val contractParser: ContractParser,
     private val createClient: CreateClient,
     private val entityManager: EntityManager,
-    private val provenanceProperties: ProvenanceProperties,
 ) : AbstractUseCase<ExecuteContractRequestWrapper, ContractExecutionResponse>() {
 
     override suspend fun execute(args: ExecuteContractRequestWrapper): ContractExecutionResponse {

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContract.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContract.kt
@@ -17,9 +17,12 @@ import io.provenance.api.domain.usecase.common.originator.EntityManager
 import io.provenance.api.domain.usecase.common.originator.models.KeyManagementConfigWrapper
 import io.provenance.api.domain.usecase.provenance.account.GetSigner
 import io.provenance.api.domain.usecase.provenance.account.models.GetSignerRequest
+import io.provenance.api.frameworks.config.ProvenanceProperties
 import io.provenance.api.frameworks.provenance.SingleTx
+import io.provenance.metadata.v1.MsgAddScopeDataAccessRequest
 import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.encryption.util.toJavaPublicKey
 import io.provenance.scope.sdk.FragmentResult
 import io.provenance.scope.sdk.SignedResult
@@ -39,11 +42,12 @@ class ExecuteContract(
     private val contractParser: ContractParser,
     private val createClient: CreateClient,
     private val entityManager: EntityManager,
+    private val provenanceProperties: ProvenanceProperties,
 ) : AbstractUseCase<ExecuteContractRequestWrapper, ContractExecutionResponse>() {
 
     override suspend fun execute(args: ExecuteContractRequestWrapper): ContractExecutionResponse {
         val signer = getSigner.execute(GetSignerRequest(args.uuid, args.request.config.account))
-        val audiences = entityManager.hydrateKeys(args.request.permissions)
+        val audiences = entityManager.hydrateKeys(args.request.permissions, args.request.participants)
         val client = createClient.execute(CreateClientRequest(args.uuid, args.request.config.account, args.request.config.client, audiences))
         val contract = contractService.getContract(args.request.config.contract.contractName)
         val records = getRecords(args.request.records, contract, args.request.config.contract.parserConfig)

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/common/originator/EntityManager.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/common/originator/EntityManager.kt
@@ -36,7 +36,7 @@ class EntityManager(
         return manager.get(args.uuid, VaultSpec(args.uuid, "${config.address}/${args.uuid}", token))
     }
 
-    fun hydrateKeys(permissions: PermissionInfo?, participants: List<Participant>, keyManagementConfig: KeyManagementConfig? = null): Set<AudienceKeyPair> {
+    fun hydrateKeys(permissions: PermissionInfo?, participants: List<Participant> = emptyList(), keyManagementConfig: KeyManagementConfig? = null): Set<AudienceKeyPair> {
 
         val additionalAudiences: MutableSet<AudienceKeyPair> = mutableSetOf()
         val config = keyManagementConfig ?: KeyManagementConfig(

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/common/originator/EntityManager.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/common/originator/EntityManager.kt
@@ -4,6 +4,7 @@ import io.provenance.api.domain.usecase.common.originator.models.KeyManagementCo
 import io.provenance.api.frameworks.config.ProvenanceProperties
 import io.provenance.api.frameworks.config.VaultProperties
 import io.provenance.api.models.account.KeyManagementConfig
+import io.provenance.api.models.account.Participant
 import io.provenance.api.models.p8e.AudienceKeyPair
 import io.provenance.api.models.p8e.PermissionInfo
 import io.provenance.core.KeyType
@@ -12,6 +13,7 @@ import io.provenance.core.OriginatorManager
 import io.provenance.core.Plugin
 import io.provenance.plugins.vault.VaultSpec
 import java.io.File
+import java.util.UUID
 import org.springframework.stereotype.Component
 import kotlin.reflect.full.createInstance
 
@@ -34,24 +36,31 @@ class EntityManager(
         return manager.get(args.uuid, VaultSpec(args.uuid, "${config.address}/${args.uuid}", token))
     }
 
-    fun hydrateKeys(permissions: PermissionInfo?, keyManagementConfig: KeyManagementConfig? = null): Set<AudienceKeyPair> {
+    fun hydrateKeys(permissions: PermissionInfo?, participants: List<Participant>, keyManagementConfig: KeyManagementConfig? = null): Set<AudienceKeyPair> {
 
+        val additionalAudiences: MutableSet<AudienceKeyPair> = mutableSetOf()
         val config = keyManagementConfig ?: KeyManagementConfig(
             vaultProperties.address,
             vaultProperties.tokenPath,
         )
 
-        val additionalAudiences: MutableSet<AudienceKeyPair> = mutableSetOf()
+        fun getEntityKeys(uuid: UUID) {
+            val originator = getEntity(KeyManagementConfigWrapper(uuid, config))
+            additionalAudiences.add(
+                AudienceKeyPair(
+                    originator.keys[KeyType.ENCRYPTION_PUBLIC_KEY].toString(),
+                    originator.keys[KeyType.SIGNING_PUBLIC_KEY].toString(),
+                )
+            )
+        }
+
+        participants.forEach { participant ->
+            getEntityKeys(participant.uuid)
+        }
 
         permissions?.audiences?.forEach {
             it.uuid?.let { entity ->
-                val originator = getEntity(KeyManagementConfigWrapper(entity, config))
-                additionalAudiences.add(
-                    AudienceKeyPair(
-                        originator.keys[KeyType.ENCRYPTION_PUBLIC_KEY].toString(),
-                        originator.keys[KeyType.SIGNING_PUBLIC_KEY].toString(),
-                    )
-                )
+                getEntityKeys(entity)
             } ?: apply {
                 it.keys?.let { keys ->
                     additionalAudiences.add(keys)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Defaulting all participants to be in the audience of a transaction

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
