### PR TITLE
Use "use{}" for closeables, fix CI linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '11'
 
       - name: Linting
-        run: ./gradlew clean ktlint --parallel
+        run: ./gradlew clean ktlint detekt --parallel --refresh-dependencies
 
   build:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
             brew install hashicorp/tap/vault
 
       - name: Gradle Build
-        run: ./gradlew build -i --parallel -x ktlint
+        run: ./gradlew clean build -i --refresh-dependencies --parallel -x ktlint -x detekt
 
       - name: Upload Test Results
         if: always()

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/reject/RejectContractBatchExecution.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/reject/RejectContractBatchExecution.kt
@@ -12,11 +12,12 @@ class RejectContractBatchExecution(
     private val createClient: CreateClient
 ) : AbstractUseCase<RejectContractBatchRequestWrapper, Unit>() {
     override suspend fun execute(args: RejectContractBatchRequestWrapper) {
-        val client = createClient.execute(CreateClientRequest(args.uuid, args.request.account, args.request.client))
+        createClient.execute(CreateClientRequest(args.uuid, args.request.account, args.request.client)).use { client ->
 
-        args.request.rejection.forEach {
-            val error = Envelopes.EnvelopeError.newBuilder().mergeFrom(it).build()
-            client.respondWithError(error)
+            args.request.rejection.forEach {
+                val error = Envelopes.EnvelopeError.newBuilder().mergeFrom(it).build()
+                client.respondWithError(error)
+            }
         }
     }
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/reject/RejectContractExecution.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/reject/RejectContractExecution.kt
@@ -13,8 +13,9 @@ class RejectContractExecution(
 ) : AbstractUseCase<RejectContractExecutionRequestWrapper, Unit>() {
 
     override suspend fun execute(args: RejectContractExecutionRequestWrapper) {
-        val client = createClient.execute(CreateClientRequest(args.uuid, args.request.account, args.request.client))
         val error = Envelopes.EnvelopeError.newBuilder().mergeFrom(args.request.rejection).build()
-        client.respondWithError(error)
+        createClient.execute(CreateClientRequest(args.uuid, args.request.account, args.request.client)).use { client ->
+            client.respondWithError(error)
+        }
     }
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/replication/EnableReplication.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/replication/EnableReplication.kt
@@ -19,9 +19,16 @@ class EnableReplication(
     private val log = KotlinLogging.logger { }
 
     override suspend fun execute(args: EnableReplicationRequest) {
-        val osClientReplicatingFrom = OsClient(URI.create(args.sourceObjectStoreAddress), objectStoreConfig.timeoutMs)
-        val publicKeyResponse = osClientReplicatingFrom.createPublicKey(args.targetSigningPublicKey.toJavaPublicKey(), args.targetEncryptionPublicKey.toJavaPublicKey(), args.targetObjectStoreAddress)
-            ?: throw IllegalStateException("Error performing operation")
+        val publicKeyResponse = OsClient(
+            URI.create(args.sourceObjectStoreAddress),
+            objectStoreConfig.timeoutMs,
+        ).use { osClientReplicatingFrom ->
+            osClientReplicatingFrom.createPublicKey(
+                args.targetSigningPublicKey.toJavaPublicKey(),
+                args.targetEncryptionPublicKey.toJavaPublicKey(),
+                args.targetObjectStoreAddress,
+            ) ?: throw IllegalStateException("Error performing operation")
+        }
         log.info("createPublicKey() response: ${publicKeyResponse.toJson()}")
     }
 }


### PR DESCRIPTION
## Context
#13 was an incomplete solution to ensuring open connections were always being closed because calling `.close()` outside of a Kotlin `use {}` or a Java `finally {}` renders it useless for ensuring a throwable does not occur between the opening and closing of a resource. So let's use `use {}` everywhere.
## Changes
### Patch
- Ensure all `Closeable` objects are only used using `use`
- Unrelated
  - Fix separation of linting in GitHub Actions workflow
## Prerequisites
- The release that contains https://github.com/provenance-io/p8e-scope-sdk/pull/60 must be used as a dependency in this project in order for `PbClient` instances returned by the `CreateClientRequest` usecase to be elegantly handled.
## Notes
- Recommend looking at the changes ignoring whitespace