### PR TITLE
File endpoint updates

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/RetrieveAndDecrypt.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/RetrieveAndDecrypt.kt
@@ -4,15 +4,14 @@ import io.provenance.api.domain.objectStore.ObjectStore
 import io.provenance.api.domain.usecase.AbstractUseCase
 import io.provenance.api.domain.usecase.common.originator.EntityManager
 import io.provenance.api.domain.usecase.common.originator.models.KeyManagementConfigWrapper
-import io.provenance.api.frameworks.config.ObjectStoreConfig
 import io.provenance.api.domain.usecase.objectStore.get.models.RetrieveAndDecryptRequest
+import io.provenance.api.frameworks.config.ObjectStoreConfig
 import io.provenance.scope.objectstore.client.OsClient
-import java.lang.IllegalStateException
 import java.net.URI
 import java.security.PrivateKey
 import java.security.PublicKey
+import org.apache.commons.codec.binary.Base64
 import org.springframework.stereotype.Component
-import java.util.Base64
 
 @Component
 class RetrieveAndDecrypt(
@@ -29,7 +28,12 @@ class RetrieveAndDecrypt(
             ?: throw IllegalStateException("Private key was not present for originator: ${args.uuid}")
 
         OsClient(URI.create(args.objectStoreAddress), objectStoreConfig.timeoutMs).use { osClient ->
-            return objectStore.retrieveAndDecrypt(osClient, Base64.getUrlDecoder().decode(args.hash), publicKey, privateKey)
+            return objectStore.retrieveAndDecrypt(osClient, decodeBase64(args.hash), publicKey, privateKey)
         }
     }
+
+    private fun decodeBase64(string: String): ByteArray =
+        string.replace(' ', '+').let {
+            Base64.decodeBase64(it)
+        }
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -57,7 +57,7 @@ class StoreFile(
             URI.create(args.request.getAsType<FormFieldPart>("objectStoreAddress").value()),
             objectStoreConfig.timeoutMs,
         ).use { osClient ->
-            if (!args.storeRawBytes) {
+            if (!args.request.getAsType<FormFieldPart>("storeRawBytes").value().toBoolean()) {
                 message = AssetOuterClassBuilders.Asset {
                     idBuilder.value = args.request.getAsType<FormFieldPart>("id").value()
                     type = FileNFT.ASSET_TYPE

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreFileRequestWrapper.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreFileRequestWrapper.kt
@@ -6,8 +6,7 @@ import org.springframework.http.codec.multipart.Part
 
 data class StoreFileRequestWrapper(
     val uuid: UUID,
-    val request: Map<String, Part>,
-    val storeRawBytes: Boolean = false,
+    val request: Map<String, Part>
 )
 
 data class SwaggerStoreFileRequestWrapper(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Recently, @jchickanosky ran into the issue that provenanced returns base64 encoded strings, but passing those strings to the `/eos/file` input will return an error. This is due to the intrinsic properties of base64 strings and how some of those characters arent allowed in url strings (`/`,`+`, `=`)

Generally, I'd like to stay away from trying to heal the hash within p8e-cee-api because recognizing intent is troublesome. I'd instead recommend always passing a url safe encoding. For example, given the hash `Rv4EXeBEIVB9oOdulG4Vsy/c/ENZ+0p0u04Dfzy3yVY=` the endpoint will think it's already url encoded. Because of this, the use case will see the string `Rv4EXeBEIVB9oOdulG4Vsy/c/ENZ 0p0u04Dfzy3yVY=` (notice the space instead of +). 

viable strings to pass instead would be: 
- `Rv4EXeBEIVB9oOdulG4Vsy%2Fc%2FENZ%2B0p0u04Dfzy3yVY%3D`
- `Rv4EXeBEIVB9oOdulG4Vsy_c_ENZ-0p0u04Dfzy3yVY`

I realize this is a bit of a pain since provenanced returns non-url-safe base64 strings. The /eos  endpoint expects a url-safe base64 strings so to convert between the two you could do something like

`Base64.getUrlEncoder().encode(Base64.getDecoder().decode(hash))`

but that's a pain. So here's whats changing: 

- Using `org.apache.commons.codec.binary.Base64.decodeBase64()` as opposed to `java.util.Base64.getUrlDecoder().decode()` as this does not care if it's in a url-safe format or not - it decodes it to a byte array either way. If the string is invalid, it forwards it do object-store in which case a `Not Found` error is returned. 
- Once again, replacing a space character with a `+` character as space will never be in a base64 formatted string. We'll see how this goes. 

unrelated to above: passing the `StoreAsRawByte` option as a part of the form data. 

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
