### PR TITLE
Add endpoint for scope ownership modification

### DIFF
--- a/models/src/main/kotlin/io/provenance/api/models/p8e/tx/ChangeScopeOwnershipRequest.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/p8e/tx/ChangeScopeOwnershipRequest.kt
@@ -1,0 +1,14 @@
+package io.provenance.api.models.p8e.tx
+
+import io.provenance.api.models.account.AccountInfo
+import io.provenance.api.models.p8e.PermissionInfo
+import io.provenance.api.models.p8e.ProvenanceConfig
+import java.util.UUID
+
+data class ChangeScopeOwnershipRequest(
+    val account: AccountInfo = AccountInfo(),
+    val provenanceConfig: ProvenanceConfig,
+    val scopeId: UUID,
+    val newValueOwner: String? = null,
+    val newDataAccess: PermissionInfo? = null,
+)

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/account/GetSigner.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/account/GetSigner.kt
@@ -17,13 +17,11 @@ class GetSigner(
     private val provenanceProperties: ProvenanceProperties,
 ) : AbstractUseCase<GetSignerRequest, Signer>() {
     override suspend fun execute(args: GetSignerRequest): Signer {
-        val utils = ProvenanceUtils()
-
         val originator = entityManager.getEntity(KeyManagementConfigWrapper(args.uuid.toString(), args.account.keyManagementConfig))
 
         return originator.signingPublicKey().let { public ->
             originator.signingPrivateKey().let { private ->
-                utils.getSigner(public as PublicKey, private as PrivateKey, provenanceProperties.mainnet)
+                ProvenanceUtils.getSigner(public as PublicKey, private as PrivateKey, provenanceProperties.mainnet)
             }
         }
     }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
@@ -41,12 +41,6 @@ class ChangeScopeOwnership(
             .takeIf { response -> response.scope.isSet() }
             ?: throw NotFoundError("No scope found")
 
-        scopeResponse.scope.scopeIdInfo.scopeUuid.let { actualScopeId ->
-            require(actualScopeId === args.request.scopeId.toString()) {
-                "Expected to fetch a scope with UUID ${args.request.scopeId} but got a UUID of $actualScopeId"
-            }
-        }
-
         val message = MsgWriteScopeRequest.newBuilder().apply {
             scopeUuid = args.request.scopeId.toString()
             specUuid = scopeResponse.scope.scopeSpecIdInfo.scopeSpecUuid

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
@@ -1,7 +1,5 @@
 package io.provenance.api.domain.usecase.provenance.tx.scope
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ObjectNode
 import io.provenance.api.domain.provenance.Provenance
 import io.provenance.api.domain.usecase.AbstractUseCase
 import io.provenance.api.domain.usecase.common.errors.NotFoundError
@@ -11,16 +9,14 @@ import io.provenance.api.domain.usecase.provenance.account.models.GetSignerReque
 import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipRequestWrapper
 import io.provenance.api.frameworks.config.ProvenanceProperties
 import io.provenance.api.frameworks.provenance.extensions.toAny
-import io.provenance.api.frameworks.provenance.extensions.toBase64String
 import io.provenance.api.frameworks.provenance.extensions.toMessageSet
+import io.provenance.api.frameworks.provenance.extensions.toModel
 import io.provenance.api.frameworks.provenance.extensions.toTxBody
-import io.provenance.api.models.p8e.TxBody
 import io.provenance.api.models.p8e.TxResponse
 import io.provenance.client.protobuf.extensions.isSet
 import io.provenance.metadata.v1.MsgWriteScopeRequest
 import io.provenance.metadata.v1.Party
 import io.provenance.metadata.v1.PartyType
-import io.provenance.scope.util.ProtoJsonUtil.toJson
 import org.springframework.stereotype.Component
 
 @Component
@@ -77,12 +73,7 @@ class ChangeScopeOwnership(
             args.request.provenanceConfig.chainId,
             args.request.provenanceConfig.nodeEndpoint,
             signer,
-            listOf(message.toAny()).toTxBody().let { cosmosTxBody ->
-                TxBody(
-                    json = ObjectMapper().readValue(cosmosTxBody.toJson(), ObjectNode::class.java),
-                    base64 = cosmosTxBody.messagesList.map { cosmosTxBody.toByteArray().toBase64String() },
-                )
-            },
+            message.toAny().toTxBody().toModel(),
         )
     }
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
@@ -1,0 +1,81 @@
+package io.provenance.api.domain.usecase.provenance.tx.scope
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.provenance.api.domain.provenance.Provenance
+import io.provenance.api.domain.usecase.AbstractUseCase
+import io.provenance.api.domain.usecase.common.errors.NotFoundError
+import io.provenance.api.domain.usecase.common.originator.EntityManager
+import io.provenance.api.domain.usecase.provenance.account.GetSigner
+import io.provenance.api.domain.usecase.provenance.account.models.GetSignerRequest
+import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipRequestWrapper
+import io.provenance.api.frameworks.config.ProvenanceProperties
+import io.provenance.api.frameworks.provenance.extensions.toAny
+import io.provenance.api.frameworks.provenance.extensions.toBase64String
+import io.provenance.api.frameworks.provenance.extensions.toMessageSet
+import io.provenance.api.frameworks.provenance.extensions.toTxBody
+import io.provenance.api.models.p8e.TxBody
+import io.provenance.api.models.p8e.TxResponse
+import io.provenance.client.protobuf.extensions.isSet
+import io.provenance.metadata.v1.MsgWriteScopeRequest
+import io.provenance.scope.util.ProtoJsonUtil.toJson
+import org.springframework.stereotype.Component
+
+@Component
+class ChangeScopeOwnership(
+    private val provenance: Provenance,
+    private val entityManager: EntityManager,
+    private val getSigner: GetSigner,
+    private val provenanceProperties: ProvenanceProperties,
+) : AbstractUseCase<ChangeScopeOwnershipRequestWrapper, TxResponse>() {
+    override suspend fun execute(args: ChangeScopeOwnershipRequestWrapper): TxResponse {
+        require(args.request.newValueOwner !== null || args.request.newDataAccess !== null) {
+            "Must request at least one change to the scope"
+        }
+
+        val signer = getSigner.execute(GetSignerRequest(args.uuid, args.request.account))
+
+        val scopeResponse = provenance.getScope(args.request.provenanceConfig, args.request.scopeId)
+            .takeIf { response -> response.scope.isSet() }
+            ?: throw NotFoundError("No scope found")
+
+        scopeResponse.scope.scopeIdInfo.scopeUuid.let { actualScopeId ->
+            require(actualScopeId === args.request.scopeId.toString()) {
+                "Expected to fetch a scope with UUID ${args.request.scopeId} but got a UUID of $actualScopeId"
+            }
+        }
+
+        val message = MsgWriteScopeRequest.newBuilder().apply {
+            scopeUuid = args.request.scopeId.toString()
+            specUuid = scopeResponse.scope.scopeSpecIdInfo.scopeSpecUuid
+            scope = scopeResponse.scope.scope.toBuilder().also { scopeBuilder ->
+                args.request.newValueOwner?.let { requestedNewValueOwner ->
+                    /** Only change value owner if [valueOwnerAddress][args.request.valueOwnerAddress] was not null. */
+                    scopeBuilder.valueOwnerAddress = requestedNewValueOwner
+                }
+                /** Only change data access if [newDataAccess][args.request.newDataAccess] was not null. */
+                args.request.newDataAccess?.let { requestedNewDataAccess ->
+                    entityManager.hydrateKeys(requestedNewDataAccess).toMessageSet(
+                        isMainnet = provenanceProperties.mainnet
+                    ).let { additionalAudiences ->
+                        scopeBuilder.clearDataAccess()
+                        scopeBuilder.addAllDataAccess(additionalAudiences)
+                    }
+                }
+            }.build()
+            addSigners(signer.address())
+        }.build()
+
+        return provenance.onboard(
+            args.request.provenanceConfig.chainId,
+            args.request.provenanceConfig.nodeEndpoint,
+            signer,
+            listOf(message.toAny()).toTxBody().let { cosmosTxBody ->
+                TxBody(
+                    json = ObjectMapper().readValue(cosmosTxBody.toJson(), ObjectNode::class.java),
+                    base64 = cosmosTxBody.messagesList.map { cosmosTxBody.toByteArray().toBase64String() },
+                )
+            },
+        )
+    }
+}

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipRequestWrapper.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipRequestWrapper.kt
@@ -1,0 +1,9 @@
+package io.provenance.api.domain.usecase.provenance.tx.scope.models
+
+import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipRequest
+import java.util.UUID
+
+data class ChangeScopeOwnershipRequestWrapper(
+    val uuid: UUID,
+    val request: ChangeScopeOwnershipRequest,
+)

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
@@ -9,16 +9,19 @@ import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastTxResponse
 import cosmos.tx.v1beta1.TxOuterClass
 import io.provenance.api.frameworks.provenance.BatchTx
 import io.provenance.api.frameworks.provenance.SingleTx
+import io.provenance.api.models.p8e.AudienceKeyPair
 import io.provenance.client.grpc.PbClient
 import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.scope.contract.proto.Contracts
+import io.provenance.scope.encryption.util.getAddress
+import io.provenance.scope.encryption.util.toJavaPublicKey
 import java.util.concurrent.TimeUnit
 
 fun BroadcastTxResponse.isError() = txResponse.isError()
 
 fun TxResponse.isError() = code > 0
 
-fun TxResponse.isSuccess() = !isError() && height > 0
+// fun TxResponse.isSuccess() = !isError() && height > 0
 
 fun TxResponse.getError(): String =
     logsList.filter { it.log.isNotBlank() }.takeIf { it.isNotEmpty() }?.joinToString("; ") { it.log } ?: rawLog
@@ -44,3 +47,7 @@ fun getCurrentHeight(pbClient: PbClient): Long = pbClient.tendermintService
 fun getBaseAccount(pbClient: PbClient, address: String): Auth.BaseAccount = pbClient.authClient
     .withDeadlineAfter(10, TimeUnit.SECONDS)
     .getBaseAccount(address)
+
+fun Set<AudienceKeyPair>.toMessageSet(isMainnet: Boolean): Set<String> = map {
+    it.signingKey.toJavaPublicKey().getAddress(isMainnet)
+}.toSet()

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions")
 package io.provenance.api.frameworks.provenance.extensions
 
 import com.google.protobuf.Any
@@ -21,7 +22,7 @@ fun BroadcastTxResponse.isError() = txResponse.isError()
 
 fun TxResponse.isError() = code > 0
 
-// fun TxResponse.isSuccess() = !isError() && height > 0
+fun TxResponse.isSuccess() = !isError() && height > 0
 
 fun TxResponse.getError(): String =
     logsList.filter { it.log.isNotBlank() }.takeIf { it.isNotEmpty() }?.joinToString("; ") { it.log } ?: rawLog

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/TxBodyExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/TxBodyExtensions.kt
@@ -1,17 +1,20 @@
 package io.provenance.api.frameworks.provenance.extensions
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.protobuf.Any
 import com.google.protobuf.Message
 import com.google.protobuf.util.JsonFormat
-import cosmos.tx.v1beta1.TxOuterClass.TxBody
 import io.provenance.metadata.v1.MsgWriteContractSpecificationRequest
 import io.provenance.metadata.v1.MsgWriteRecordRequest
 import io.provenance.metadata.v1.MsgWriteRecordSpecificationRequest
 import io.provenance.metadata.v1.MsgWriteScopeRequest
 import io.provenance.metadata.v1.MsgWriteScopeSpecificationRequest
 import io.provenance.metadata.v1.MsgWriteSessionRequest
+import cosmos.tx.v1beta1.TxOuterClass.TxBody as CosmosTxBody
+import io.provenance.api.models.p8e.TxBody as TxBodyModel
 
-fun TxBody.toJson(): String {
+fun CosmosTxBody.toJson(): String {
     val printer: JsonFormat.Printer = JsonFormat.printer().usingTypeRegistry(
         JsonFormat.TypeRegistry.newBuilder()
             .add(MsgWriteContractSpecificationRequest.getDescriptor())
@@ -27,8 +30,8 @@ fun TxBody.toJson(): String {
 
 fun Message.toAny(typeUrlPrefix: String = ""): Any = Any.pack(this, typeUrlPrefix)
 
-fun Iterable<Any>.toTxBody(memo: String? = null, timeoutHeight: Long? = null): TxBody =
-    TxBody.newBuilder()
+fun Iterable<Any>.toTxBody(memo: String? = null, timeoutHeight: Long? = null): CosmosTxBody =
+    CosmosTxBody.newBuilder()
         .addAllMessages(this)
         .also { builder ->
             memo?.run { builder.memo = this }
@@ -36,5 +39,10 @@ fun Iterable<Any>.toTxBody(memo: String? = null, timeoutHeight: Long? = null): T
         }
         .build()
 
-fun Any.toTxBody(memo: String? = null, timeoutHeight: Long? = null): TxBody =
+fun Any.toTxBody(memo: String? = null, timeoutHeight: Long? = null): CosmosTxBody =
     listOf(this).toTxBody(memo, timeoutHeight)
+
+fun CosmosTxBody.toModel() = TxBodyModel(
+    json = ObjectMapper().readValue(toJson(), ObjectNode::class.java),
+    base64 = messagesList.map { message -> message.toByteArray().toBase64String() },
+)

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/utility/ProvenanceUtils.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/utility/ProvenanceUtils.kt
@@ -31,7 +31,7 @@ import java.security.PrivateKey
 import java.security.PublicKey
 import java.util.UUID
 
-class ProvenanceUtils {
+object ProvenanceUtils {
 
     data class RecordInputSpec(
         val name: String,
@@ -39,23 +39,20 @@ class ProvenanceUtils {
         val hash: String,
     )
 
-    companion object {
-
-        // Record specification
-        const val RecordSpecName = "Asset"
-        val RecordSpecInputs = listOf(
-            RecordInputSpec(
-                name = "AssetHash",
-                typeName = "String",
-                hash = "4B6A6C36E8B2622334C244B46799A47DBEAAF94E9D5B7637BC12A3A4988A62C0", // sha356(RecordSpecInputs.name)
-            )
+    // Record specification
+    const val RecordSpecName = "Asset"
+    val RecordSpecInputs = listOf(
+        RecordInputSpec(
+            name = "AssetHash",
+            typeName = "String",
+            hash = "4B6A6C36E8B2622334C244B46799A47DBEAAF94E9D5B7637BC12A3A4988A62C0", // sha356(RecordSpecInputs.name)
         )
+    )
 
-        // Record process
-        const val RecordProcessName = "OnboardAssetProcess"
-        const val RecordProcessMethod = "OnboardAsset"
-        const val RecordProcessHash = "32D60974A2B2E9A9D9E93D9956E3A7D2BD226E1511D64D1EA39F86CBED62CE78" // sha356(RecordProcessMethod)
-    }
+    // Record process
+    const val RecordProcessName = "OnboardAssetProcess"
+    const val RecordProcessMethod = "OnboardAsset"
+    const val RecordProcessHash = "32D60974A2B2E9A9D9E93D9956E3A7D2BD226E1511D64D1EA39F86CBED62CE78" // sha356(RecordProcessMethod)
 
     // Create a metadata TX message for a new scope onboard
     private fun buildNewScopeMetadataTransaction(

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/utility/ProvenanceUtils.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/utility/ProvenanceUtils.kt
@@ -1,7 +1,5 @@
 package io.provenance.api.frameworks.provenance.utility
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ObjectNode
 import cosmos.crypto.secp256k1.Keys
 import cosmos.tx.v1beta1.TxOuterClass
 import io.provenance.client.grpc.Signer
@@ -20,8 +18,7 @@ import io.provenance.metadata.v1.ResultStatus
 import io.provenance.api.domain.usecase.common.model.ScopeConfig
 import io.provenance.api.models.p8e.TxBody
 import io.provenance.api.frameworks.provenance.extensions.toAny
-import io.provenance.api.frameworks.provenance.extensions.toBase64String
-import io.provenance.api.frameworks.provenance.extensions.toJson
+import io.provenance.api.frameworks.provenance.extensions.toModel
 import io.provenance.api.frameworks.provenance.extensions.toTxBody
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.util.MetadataAddress
@@ -168,10 +165,7 @@ object ProvenanceUtils {
             additionalAudiences,
         )
 
-        return TxBody(
-            json = ObjectMapper().readValue(txBody.toJson(), ObjectNode::class.java),
-            base64 = txBody.messagesList.map { it.toByteArray().toBase64String() }
-        )
+        return txBody.toModel()
     }
 
     fun getSigner(publicKey: PublicKey, privateKey: PrivateKey, isMainnet: Boolean): Signer {

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
@@ -6,12 +6,13 @@ import io.provenance.api.models.p8e.TxBody
 import io.provenance.api.models.p8e.TxResponse
 import io.provenance.api.models.p8e.contracts.ClassifyAssetRequest
 import io.provenance.api.models.p8e.contracts.VerifyAssetRequest
+import io.provenance.api.models.p8e.query.QueryScopeResponse
+import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipRequest
 import io.provenance.api.models.p8e.tx.CreateTxRequest
 import io.provenance.api.models.p8e.tx.ExecuteTxRequest
 import io.provenance.api.models.p8e.tx.permissions.authz.UpdateAuthzRequest
 import io.provenance.api.models.p8e.tx.permissions.dataAccess.UpdateScopeDataAccessRequest
 import tech.figure.classification.asset.client.domain.model.AssetDefinition
-import io.provenance.metadata.v1.ScopeResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
@@ -148,10 +149,39 @@ class ProvenanceApi {
                     ApiResponse(
                         responseCode = "200",
                         description = "successful operation",
-                        content = [Content(schema = Schema(implementation = ScopeResponse::class))]
+                        content = [Content(schema = Schema(implementation = QueryScopeResponse::class))]
                     )
                 ]
             )
+        ),
+        RouterOperation(
+            path = "${Routes.EXTERNAL_BASE_V1}/p8e/scope/ownership",
+            method = arrayOf(RequestMethod.POST),
+            produces = ["application/json"],
+            operation = Operation(
+                tags = ["Provenance"],
+                operationId = "changeScopeOwnership",
+                method = "POST",
+                parameters = [
+                    Parameter(
+                        name = "x-uuid",
+                        required = true,
+                        `in` = ParameterIn.HEADER,
+                        schema = Schema(implementation = UUID::class),
+                    ),
+                ],
+                requestBody = RequestBody(
+                    required = true,
+                    content = [Content(schema = Schema(implementation = ChangeScopeOwnershipRequest::class))]
+                ),
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        description = "successful operation",
+                        content = [Content(schema = Schema(implementation = TxResponse::class))]
+                    )
+                ]
+            ),
         ),
         RouterOperation(
             path = "${Routes.EXTERNAL_BASE_V1}/p8e/classify",
@@ -380,7 +410,10 @@ class ProvenanceApi {
                 GET("/status", handler::getClassificationStatus)
                 GET("/fees", handler::getFees)
             }
-            GET("/scope/query", handler::queryScope)
+            "/scope".nest {
+                GET("/query", handler::queryScope)
+                POST("/ownership", handler::changeScopeOwnership)
+            }
             POST("/verify", handler::verifyAsset)
             "/permissions".nest {
                 PATCH("/data", handler::updateDataAccess)

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceHandler.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceHandler.kt
@@ -17,6 +17,8 @@ import io.provenance.api.domain.usecase.provenance.tx.permissions.authz.UpdateAu
 import io.provenance.api.domain.usecase.provenance.tx.permissions.authz.models.UpdateAuthzRequestWrapper
 import io.provenance.api.domain.usecase.provenance.tx.permissions.dataAccess.UpdateScopeDataAccess
 import io.provenance.api.domain.usecase.provenance.tx.permissions.dataAccess.models.UpdateScopeDataAccessRequestWrapper
+import io.provenance.api.domain.usecase.provenance.tx.scope.ChangeScopeOwnership
+import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipRequestWrapper
 import io.provenance.api.frameworks.web.misc.foldToServerResponse
 import io.provenance.api.frameworks.web.misc.getUser
 import io.provenance.api.models.p8e.query.QueryScopeRequest
@@ -31,6 +33,7 @@ class ProvenanceHandler(
     private val executeTx: ExecuteTx,
     private val createTx: CreateTx,
     private val queryScope: QueryScope,
+    private val changeScopeOwnership: ChangeScopeOwnership,
     private val classifyAsset: ClassifyAsset,
     private val verifyAsset: VerifyAsset,
     private val getFees: GetFeesForAsset,
@@ -54,6 +57,15 @@ class ProvenanceHandler(
                 req.queryParam("chainId").get(),
                 req.queryParam("nodeEndpoint").get(),
                 req.queryParam("objectStoreUrl").get(),
+            )
+        )
+    }.foldToServerResponse()
+
+    suspend fun changeScopeOwnership(req: ServerRequest): ServerResponse = runCatching {
+        changeScopeOwnership.execute(
+            ChangeScopeOwnershipRequestWrapper(
+                req.getUser(),
+                req.awaitBody(),
             )
         )
     }.foldToServerResponse()

--- a/service/src/test/kotlin/io/provenance/api/integration/base/IntegrationTestBase.kt
+++ b/service/src/test/kotlin/io/provenance/api/integration/base/IntegrationTestBase.kt
@@ -55,6 +55,7 @@ class IntegrationTestBase(body: WordSpec.() -> Unit = {}) : WordSpec(body) {
         // could not be found. related github issue: https://github.com/testcontainers/testcontainers-java/issues/4281
         const val objectStoreAddress = "grpc://localhost:9993"
         const val vaultAddress = "http://localhost:8200/v1/kv2_originations/data/originators"
+        const val provenanceAddress = "grpc://localhost:9090"
 
 //        val objectStoreContainer: ContainerState by lazy { instance.getContainerByServiceName("object-store_1").get() }
 //        val vaultContainer: ContainerState by lazy { instance.getContainerByServiceName("vault_1").get() }

--- a/service/src/test/kotlin/io/provenance/api/integration/tx/ChangeScopeOwnershipTest.kt
+++ b/service/src/test/kotlin/io/provenance/api/integration/tx/ChangeScopeOwnershipTest.kt
@@ -1,0 +1,45 @@
+package io.provenance.api.integration.tx
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import io.provenance.api.domain.usecase.provenance.tx.scope.ChangeScopeOwnership
+import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipRequestWrapper
+import io.provenance.api.integration.base.IntegrationTestBase
+import io.provenance.api.models.p8e.ProvenanceConfig
+import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipRequest
+import io.provenance.scope.util.toUuid
+import java.util.UUID
+
+class ChangeScopeOwnershipTest(
+    private val changeScopeOwnership: ChangeScopeOwnership,
+) : IntegrationTestBase({
+    val testEntityId = "deadbeef-face-479b-860c-facefaceface".toUuid()
+    "Changing scope ownership" should {
+        "throw an exception when no changes to the scope are specified" {
+            shouldThrow<IllegalArgumentException> {
+                changeScopeOwnership.execute(
+                    ChangeScopeOwnershipRequestWrapper(
+                        testEntityId,
+                        ChangeScopeOwnershipRequest(
+                            provenanceConfig = ProvenanceConfig(
+                                chainId = "chain-local",
+                                nodeEndpoint = provenanceAddress,
+                            ),
+                            scopeId = UUID.randomUUID(),
+                            newValueOwner = null,
+                            newDataAccess = null,
+                        )
+                    )
+                )
+            }.let { exception ->
+                exception.message shouldContain "Must request at least one change to the scope"
+            }
+        }
+        "allow the value owner of an existing scope to be changed" {
+            // TODO - Implement
+        }
+        "allow the data access list of an existing scope to be changed" {
+            // TODO - Implement
+        }
+    }
+})


### PR DESCRIPTION
## Context
Adding an endpoint to conveniently alter the value owner and/or data access list of a scope
## Changes
### Minor
- Add endpoint for changing scope ownership
### Patch
- Change `ProvenanceUtils` to an `object`
- Fix typo in Swagger documentation for scope query endpoint
