### PR TITLE
Change scope data access endpoint path & fix incorrect Swagger paths

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
@@ -242,7 +242,7 @@ class ProvenanceApi {
             )
         ),
         RouterOperation(
-            path = "${Routes.EXTERNAL_BASE_V1}/p8e/fees",
+            path = "${Routes.EXTERNAL_BASE_V1}/p8e/classify/fees",
             method = arrayOf(RequestMethod.GET),
             produces = ["application/json"],
             operation = Operation(
@@ -340,7 +340,7 @@ class ProvenanceApi {
             )
         ),
         RouterOperation(
-            path = "${Routes.EXTERNAL_BASE_V1}/p8e/permissions/data-access",
+            path = "${Routes.EXTERNAL_BASE_V1}/p8e/scope/data",
             method = arrayOf(RequestMethod.PATCH),
             produces = ["application/json"],
             operation = Operation(
@@ -413,12 +413,10 @@ class ProvenanceApi {
             "/scope".nest {
                 GET("/query", handler::queryScope)
                 POST("/ownership", handler::changeScopeOwnership)
+                PATCH("/data", handler::updateDataAccess)
             }
             POST("/verify", handler::verifyAsset)
-            "/permissions".nest {
-                PATCH("/data", handler::updateDataAccess)
-                PATCH("/authz", handler::updateAuthz)
-            }
+            PATCH("/permissions/authz", handler::updateAuthz)
         }
     }
 }


### PR DESCRIPTION
## Context
Per https://github.com/provenance-io/p8e-cee-api/pull/60/#discussion_r977945748, let's change the path of the endpoint for updating a scope's data access list from `/p8e/permissions/data` to `/p8e/scope/data`. We can leave `/p8e/permissions/authz` be.
## Changes
### Minor
- Change endpoint for updating a scope's data access list from `/p8e/permissions/data` to `/p8e/scope/data`
### Patch
- Fix more mistakes in Swagger endpoint paths