### PR TITLE
File Part Byte Issue

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/util/MultiPartExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/util/MultiPartExtensions.kt
@@ -1,13 +1,8 @@
 package io.provenance.api.util
 
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.http.codec.multipart.FilePart
-import java.io.ByteArrayOutputStream
 
-suspend fun FilePart.awaitAllBytes(): ByteArray = ByteArrayOutputStream().use { stream ->
-    /* read all data frames from the request, then concat together via the output stream */
-    content().collectList().awaitSingle().forEach { buffer ->
-        stream.writeBytes(buffer.asByteBuffer().array())
-    }
-    stream.toByteArray()
-}
+suspend fun FilePart.awaitAllBytes(): ByteArray =
+    DataBufferUtils.join(this.content()).map { it.asByteBuffer().array() }.awaitSingle()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

There's an issue with sending in large text files to the /eos/file endpoint. A file like 

```
...
FkD6TcTHXp5mkecHJy59e6YawLy7+qa9c8b3puypbo/uPdIl/rPJpfLrSxE5fYomciffVq5eSmzdFcgMZOGvmbFmCmAaY9COUUGQ1lRJpeKa4O67igW8dIxNv+cmUYpPU4zGSDSe7gg0aw0AKBtz2pG5gbaIXa5S0yf1CoftvHTtK7Ugd9y4AAAAASUVORK5CYII=
```

appends non-ascii characters after awaiting the byte array from the Mono flux object. This is eventually problematic since data is malformed in EOS: 

![Screen Shot 2022-09-29 at 10 01 18 AM](https://user-images.githubusercontent.com/87503067/193093429-8949218c-75db-4fb4-94cf-9e1e4494ecd1.png)

Now using `DataBufferUtils` which appears to correctly transform the MultipartFile object into a byte array. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
