### PR TITLE
Rate Limiting API requests

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/GetFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/GetFile.kt
@@ -2,11 +2,15 @@ package io.provenance.api.domain.usecase.objectStore.get
 
 import com.google.protobuf.BytesValue
 import com.google.protobuf.StringValue
+import cosmos.bank.v1beta1.QueryOuterClass
 import io.provenance.api.domain.extensions.toByteResponse
 import io.provenance.api.domain.usecase.AbstractUseCase
 import io.provenance.api.domain.usecase.objectStore.get.models.GetFileRequestWrapper
 import io.provenance.api.domain.usecase.objectStore.get.models.RetrieveAndDecryptRequest
+import io.provenance.client.grpc.GasEstimationMethod
+import io.provenance.client.grpc.PbClient
 import io.provenance.client.protobuf.extensions.isSet
+import java.net.URI
 import org.springframework.stereotype.Component
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.proto.util.FileNFT
@@ -16,6 +20,17 @@ class GetFile(
     private val retrieveAndDecrypt: RetrieveAndDecrypt,
 ) : AbstractUseCase<GetFileRequestWrapper, Any>() {
     override suspend fun execute(args: GetFileRequestWrapper): Any {
+        PbClient("pio-testnet-1-", URI("grpc://34.148.39.82:9090"), GasEstimationMethod.MSG_FEE_CALCULATION).use {
+            println(
+                it.bankClient.balance(
+                    QueryOuterClass.QueryBalanceRequest.newBuilder()
+                        .setAddress("tp1lz0kffhs3fggvnqq9t0r40trys90pa880l9q8u")
+                        .setDenom("hash")
+                        .build()
+                )
+            )
+        }
+
         retrieveAndDecrypt.execute(RetrieveAndDecryptRequest(args.uuid, args.request.objectStoreAddress, args.request.hash, args.request.accountInfo.keyManagementConfig)).let {
             if (args.request.rawBytes) {
                 return it

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/GetFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/get/GetFile.kt
@@ -2,15 +2,11 @@ package io.provenance.api.domain.usecase.objectStore.get
 
 import com.google.protobuf.BytesValue
 import com.google.protobuf.StringValue
-import cosmos.bank.v1beta1.QueryOuterClass
 import io.provenance.api.domain.extensions.toByteResponse
 import io.provenance.api.domain.usecase.AbstractUseCase
 import io.provenance.api.domain.usecase.objectStore.get.models.GetFileRequestWrapper
 import io.provenance.api.domain.usecase.objectStore.get.models.RetrieveAndDecryptRequest
-import io.provenance.client.grpc.GasEstimationMethod
-import io.provenance.client.grpc.PbClient
 import io.provenance.client.protobuf.extensions.isSet
-import java.net.URI
 import org.springframework.stereotype.Component
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.proto.util.FileNFT
@@ -20,17 +16,6 @@ class GetFile(
     private val retrieveAndDecrypt: RetrieveAndDecrypt,
 ) : AbstractUseCase<GetFileRequestWrapper, Any>() {
     override suspend fun execute(args: GetFileRequestWrapper): Any {
-        PbClient("pio-testnet-1-", URI("grpc://34.148.39.82:9090"), GasEstimationMethod.MSG_FEE_CALCULATION).use {
-            println(
-                it.bankClient.balance(
-                    QueryOuterClass.QueryBalanceRequest.newBuilder()
-                        .setAddress("tp1lz0kffhs3fggvnqq9t0r40trys90pa880l9q8u")
-                        .setDenom("hash")
-                        .build()
-                )
-            )
-        }
-
         retrieveAndDecrypt.execute(RetrieveAndDecryptRequest(args.uuid, args.request.objectStoreAddress, args.request.hash, args.request.accountInfo.keyManagementConfig)).let {
             if (args.request.rawBytes) {
                 return it

--- a/service/src/main/kotlin/io/provenance/api/frameworks/config/RateLimiterConfig.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/config/RateLimiterConfig.kt
@@ -1,0 +1,11 @@
+package io.provenance.api.frameworks.config
+
+import com.google.common.util.concurrent.RateLimiter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RateLimiterConfig {
+    @Bean
+    fun rateLimiter() = RateLimiter.create(5.0)
+}

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/internal/objectStore/InternalObjectStoreApi.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/internal/objectStore/InternalObjectStoreApi.kt
@@ -1,18 +1,21 @@
 package io.provenance.api.frameworks.web.internal.objectStore
 
+import com.google.common.util.concurrent.RateLimiter
 import io.provenance.api.frameworks.web.Routes
 import io.provenance.api.frameworks.web.logging.logExchange
+import io.provenance.api.frameworks.web.misc.rateLimitedCoRouter
 import mu.KotlinLogging
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.reactive.function.server.coRouter
 
 private val log = KotlinLogging.logger {}
 
 @Configuration
-class InternalObjectStoreApi {
+class InternalObjectStoreApi(
+    private val rateLimiter: RateLimiter
+) {
     @Bean
-    fun internalObjectStoreApiV1(handler: InternalObjectStoreHandler) = coRouter {
+    fun internalObjectStoreApiV1(handler: InternalObjectStoreHandler) = rateLimitedCoRouter(rateLimiter) {
         logExchange(log)
         Routes.INTERNAL_BASE_V1.nest {
             "/eos".nest {

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/misc/CoRouterExt.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/misc/CoRouterExt.kt
@@ -1,0 +1,24 @@
+package io.provenance.api.frameworks.web.misc
+
+import com.google.common.util.concurrent.RateLimiter
+import java.util.concurrent.TimeUnit
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.server.CoRouterFunctionDsl
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.buildAndAwait
+import org.springframework.web.reactive.function.server.coRouter
+
+fun CoRouterFunctionDsl.rateLimited(limiter: RateLimiter) {
+    filter { request, handler ->
+        if (limiter.tryAcquire(1, 10, TimeUnit.SECONDS)) {
+            handler(request)
+        } else {
+            ServerResponse.status(HttpStatus.TOO_MANY_REQUESTS).buildAndAwait()
+        }
+    }
+}
+
+fun rateLimitedCoRouter(rateLimiter: RateLimiter, routes: (CoRouterFunctionDsl.() -> Unit)) = coRouter {
+    rateLimited(rateLimiter)
+    apply(routes)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Observed the pod in the production cluster was exiting from OOM exceptions. I believe this is due to the large amount of API requests made against `/eos/file`. 

Putting in place a rate limiter to allow no more than 5 requests per second, with a backoff waiting period of 10 seconds per permit.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
