### PR TITLE
refactoring store file

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -36,11 +36,10 @@ class StoreFile(
         val (keyConfig, additionalAudiences, objectStoreAddress, storeRawBytes, id, file) = getParams(args.request)
         val originator = entityManager.getEntity(KeyManagementConfigWrapper(args.uuid.toString(), keyConfig))
 
-        lateinit var result: StoreProtoResponse
         OsClient(URI.create(objectStoreAddress), objectStoreConfig.timeoutMs).use { osClient ->
             val bytes = file.awaitAllBytes()
             ByteArrayInputStream(bytes).use { message ->
-                result = objectStore.store(
+                return objectStore.store(
                     osClient,
                     if (!storeRawBytes)
                         AssetOuterClassBuilders.Asset {
@@ -57,8 +56,6 @@ class StoreFile(
                 )
             }
         }
-
-        return result
     }
 
     private fun getParams(request: Map<String, Part>): Args {

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -33,53 +33,68 @@ class StoreFile(
     private val entityManager: EntityManager,
 ) : AbstractUseCase<StoreFileRequestWrapper, StoreProtoResponse>() {
     override suspend fun execute(args: StoreFileRequestWrapper): StoreProtoResponse {
+        val (keyConfig, additionalAudiences, objectStoreAddress, storeRawBytes, id, file) = getParams(args.request)
+        val originator = entityManager.getEntity(KeyManagementConfigWrapper(args.uuid.toString(), keyConfig))
+
+        lateinit var result: StoreProtoResponse
+        OsClient(URI.create(objectStoreAddress), objectStoreConfig.timeoutMs).use { osClient ->
+            val bytes = file.awaitAllBytes()
+            ByteArrayInputStream(bytes).use { message ->
+                result = objectStore.store(
+                    osClient,
+                    if (!storeRawBytes)
+                        AssetOuterClassBuilders.Asset {
+                            idBuilder.value = id
+                            type = FileNFT.ASSET_TYPE
+                            description = file.filename()
+                            putKv(FileNFT.KEY_FILENAME, file.filename().toProtoAny())
+                            putKv(FileNFT.KEY_BYTES, bytes.toProtoAny())
+                            putKv(FileNFT.KEY_SIZE, bytes.size.toString().toProtoAny())
+                            putKv(FileNFT.KEY_CONTENT_TYPE, file.headers().contentType.toString().toProtoAny())
+                        } else message,
+                    originator.encryptionPublicKey() as PublicKey,
+                    additionalAudiences.map { it.encryptionKey.toJavaPublicKey() }.toSet()
+                )
+            }
+        }
+
+        return result
+    }
+
+    private fun getParams(request: Map<String, Part>): Args {
         var additionalAudiences = emptySet<AudienceKeyPair>()
         var keyConfig: KeyManagementConfig? = null
 
-        args.request["account"]?.let {
+        request["account"]?.let {
             keyConfig = Gson().fromJson((it as FormFieldPart).value(), AccountInfo::class.java).keyManagementConfig
         }
 
-        if (!args.request.containsKey("id") || args.request.getAsType<FormFieldPart>("id").value().isEmpty()) {
+        if (!request.containsKey("id") || request.getAsType<FormFieldPart>("id").value().isEmpty()) {
             throw IllegalArgumentException("Request must provide the 'id' field for the file")
         }
 
-        args.request["permissions"]?.let {
+        request["permissions"]?.let {
             val permissions = Gson().fromJson((it as FormFieldPart).value(), PermissionInfo::class.java)
             additionalAudiences = entityManager.hydrateKeys(permissions)
         }
 
-        val originator = entityManager.getEntity(KeyManagementConfigWrapper(args.uuid.toString(), keyConfig))
-        val file = args.request.getAsType<FilePart>("file")
-        var message: Any = ByteArrayInputStream(file.awaitAllBytes())
-
-        OsClient(
-            URI.create(args.request.getAsType<FormFieldPart>("objectStoreAddress").value()),
-            objectStoreConfig.timeoutMs,
-        ).use { osClient ->
-            if (!args.request.getAsType<FormFieldPart>("storeRawBytes").value().toBoolean()) {
-                message = AssetOuterClassBuilders.Asset {
-                    idBuilder.value = args.request.getAsType<FormFieldPart>("id").value()
-                    type = FileNFT.ASSET_TYPE
-                    description = file.filename()
-
-                    putKv(FileNFT.KEY_FILENAME, file.filename().toProtoAny())
-                    putKv(FileNFT.KEY_BYTES, file.awaitAllBytes().toProtoAny())
-                    putKv(FileNFT.KEY_SIZE, file.awaitAllBytes().size.toString().toProtoAny())
-                    putKv(FileNFT.KEY_CONTENT_TYPE, file.headers().contentType.toString().toProtoAny())
-                }
-            }
-
-            return objectStore.store(
-                osClient,
-                message,
-                originator.encryptionPublicKey() as PublicKey,
-                additionalAudiences.map { it.encryptionKey.toJavaPublicKey() }.toSet()
-            )
-        }
+        val objectStoreAddress = request.getAsType<FormFieldPart>("objectStoreAddress").value()
+        val storeRawBytes = request.getAsType<FormFieldPart>("storeRawBytes").value().toBoolean()
+        val id = request.getAsType<FormFieldPart>("id").value()
+        val file = request.getAsType<FilePart>("file")
+        return Args(keyConfig, additionalAudiences, objectStoreAddress, storeRawBytes, id, file)
     }
 
     private inline fun <reified T> Map<String, Part>.getAsType(key: String): T =
         T::class.java.cast(get(key))
             ?: throw IllegalArgumentException("Failed to retrieve and cast provided argument.")
+
+    data class Args(
+        val keyConfig: KeyManagementConfig?,
+        val additionalAudiences: Set<AudienceKeyPair>,
+        val objectStoreAddress: String,
+        val storeRawBytes: Boolean,
+        val id: String,
+        val file: FilePart,
+    )
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Refactoring Store File endpoint. This change primarily does: 

- using `.use {}` on the byteArrayInputStream to be sure it's being closed properly. 
- calling `file.awaitAllBytes()` once instead of multiple times 
- general cleanup for clarity 

I don't believe this is the cause to the memory issue itself, but given that temp deploying to `p8e-cee-api` is very hard, might as well check this in and see. 
closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
