### PR TITLE
Add JsonTypeInfo to sealed class

### DIFF
--- a/models/src/main/kotlin/io/provenance/api/models/cee/execute/ContractExecutionResponse.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/cee/execute/ContractExecutionResponse.kt
@@ -1,28 +1,43 @@
 package io.provenance.api.models.cee.execute
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import io.provenance.api.models.p8e.TxResponse
 import java.util.UUID
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = SinglePartyContractExecutionResponse::class, name = "single"),
+    JsonSubTypes.Type(value = MultipartyContractExecutionResponse::class, name = "multi"),
+    JsonSubTypes.Type(value = ContractExecutionErrorResponse::class, name = "error"),
+)
 sealed class ContractExecutionResponse(
     open val scopeUuids: List<UUID>,
     open val error: String? = null,
     val multiparty: Boolean? = null,
 )
 
+@JsonTypeName("single")
 data class SinglePartyContractExecutionResponse(
+    val type: String = "single",
     val metadata: TxResponse?,
     override val error: String? = null,
     override val scopeUuids: List<UUID>
 ) : ContractExecutionResponse(error = error, multiparty = false, scopeUuids = scopeUuids)
 
+@JsonTypeName("multi")
 data class MultipartyContractExecutionResponse(
+    val type: String = "multi",
     val envelopeState: String?,
     override val error: String? = null,
     override val scopeUuids: List<UUID>
 ) : ContractExecutionResponse(error = error, multiparty = true, scopeUuids = scopeUuids)
 
+@JsonTypeName("error")
 data class ContractExecutionErrorResponse(
-    val type: String? = null,
+    val type: String = "error",
+    val errorType: String? = null,
     override val error: String,
     override val scopeUuids: List<UUID>
 ) : ContractExecutionResponse(error = error, scopeUuids = scopeUuids)

--- a/models/src/main/kotlin/io/provenance/api/models/cee/execute/ExecuteContractBatchRequest.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/cee/execute/ExecuteContractBatchRequest.kt
@@ -1,11 +1,13 @@
 package io.provenance.api.models.cee.execute
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import io.provenance.api.models.account.Participant
 import io.provenance.api.models.p8e.PermissionInfo
 
 data class ExecuteContractBatchRequest(
     val config: ExecuteContractConfig,
     val records: Map<String, Any>,
+    @JsonAlias("participants")
     val additionalParticipants: List<Participant> = emptyList(),
     val permissions: PermissionInfo?,
     val chunkSize: Int = 25,

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContractBatch.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/cee/execute/ExecuteContractBatch.kt
@@ -58,7 +58,11 @@ class ExecuteContractBatch(
                     },
                     onFailure = { error ->
                         errors.add(
-                            ContractExecutionErrorResponse("Contract Execution Exception", error.toPrettyJson(), listOf(it.scopeUuid))
+                            ContractExecutionErrorResponse(
+                                errorType = "Contract Execution Exception",
+                                error = error.toPrettyJson(),
+                                scopeUuids = listOf(it.scopeUuid)
+                            )
                         )
                     }
                 )
@@ -84,7 +88,11 @@ class ExecuteContractBatch(
                     },
                     onFailure = { error ->
                         errors.add(
-                            ContractExecutionErrorResponse("Signed Tx Execution Exception", error.toPrettyJson(), chunk.map { it.first })
+                            ContractExecutionErrorResponse(
+                                errorType = "Signed Tx Execution Exception",
+                                error = error.toPrettyJson(),
+                                scopeUuids = chunk.map { it.first }
+                            )
                         )
                     }
                 )
@@ -108,7 +116,11 @@ class ExecuteContractBatch(
                         },
                         onFailure = {
                             errors.add(
-                                ContractExecutionErrorResponse("Fragment Tx Execution Exception", it.toPrettyJson(), listOf(result.first))
+                                ContractExecutionErrorResponse(
+                                    errorType = "Fragment Tx Execution Exception",
+                                    error = it.toPrettyJson(),
+                                    scopeUuids = listOf(result.first)
+                                )
                             )
                         }
                     )

--- a/service/src/main/resources/application-local.properties
+++ b/service/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+# Spring boot server settings
+server.port=8080


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Jackson is unable to deserialize the result of calling the execute batch contract endpoint because it returns a sealed class.

Error message: `Cannot construct instance of 'io.provenance.api.models.cee.execute.ContractExecutionResponse' (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information`

Adding JsonTypeInfo and names to each sub class should help.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
