### PR TITLE
Add support for prerelease of Docker images, fix other minutiae

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,20 @@ on:
     types: [ published ]
   workflow_dispatch:
     inputs:
+      versionTag:
+        type: string
+        description: Version tag to use for the Docker image and Maven JAR
+        required: true
       tagAsLatest:
         type: boolean
-        description: Tag as latest
+        description: Tag the Docker image as latest
         required: true
-        default: true
+        default: false
+      publishToMaven:
+        type: boolean
+        description: Publish the JAR to Maven Central
+        required: true
+        default: false
 
 jobs:
   release:
@@ -43,15 +52,18 @@ jobs:
         run: |
           DOCKER_IMAGE=provenanceio/p8e-cee-api
           VERSION=$( echo ${{ github.event.release.tag_name }} | sed -e 's/^v//' )
+          if [ "$VERSION" == "" ] ; then
+            VERSION=$( echo ${{ github.event.inputs.versionTag }} | sed -e 's/^v//' )
+          fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 
           if [ ${{ github.event.inputs.tagAsLatest }} == 'true' ] ; then
             TAGS="${TAGS},${DOCKER_IMAGE}:latest"
           fi
 
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -78,6 +90,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
+        if: github.event.inputs.publishToMaven
         run: |
           ./gradlew publishToSonatype -Pversion=${{ steps.ci-release-create-outputs.outputs.version }} $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
           -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           tags: ${{ steps.ci-release-create-outputs.outputs.tags }}
 
       - name: Install gpg secret key
-        if: github.event.inputs.publishToMaven
+        if: github.event.inputs.publishToMaven == true
         run: |
           export GPG_TTY=$(tty)
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode | gpg --batch --import
@@ -91,7 +91,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
-        if: github.event.inputs.publishToMaven
+        if: github.event.inputs.publishToMaven == true
         run: |
           ./gradlew publishToSonatype -Pversion=${{ steps.ci-release-create-outputs.outputs.version }} $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
           -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,16 +66,16 @@ jobs:
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: service/docker/Dockerfile
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           tags: ${{ steps.ci-release-create-outputs.outputs.tags }}
 
       - name: Install gpg secret key
+        if: github.event.inputs.publishToMaven
         run: |
           export GPG_TTY=$(tty)
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode | gpg --batch --import

--- a/models/src/main/kotlin/io/provenance/api/models/cee/execute/ExecuteContractRequest.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/cee/execute/ExecuteContractRequest.kt
@@ -1,5 +1,6 @@
 package io.provenance.api.models.cee.execute
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import io.provenance.api.models.account.Participant
 import io.provenance.api.models.p8e.PermissionInfo
 
@@ -7,6 +8,7 @@ data class ExecuteContractRequest(
     val scope: ScopeInfo,
     val config: ExecuteContractConfig,
     val records: Map<String, Any>,
+    @JsonAlias("participants")
     val additionalParticipants: List<Participant> = emptyList(),
     val permissions: PermissionInfo? = null,
 )


### PR DESCRIPTION
## Changes
- Add support for creating prerelease Docker images of the service
- Update [deprecated syntax](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in the release workflow
- Add backwards compatibility for the `ExecuteContractRequest` modification made in #87
- Update Docker action versions in release workflow to latest
- Set Maven publishing option default from true to false in release workflow