### PR TITLE
Fix Maven publishing not occurring on release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           tags: ${{ steps.ci-release-create-outputs.outputs.tags }}
 
       - name: Install gpg secret key
-        if: github.event.inputs.publishToMaven == true
+        if: github.event.inputs.publishToMaven == true || github.event_name == 'release'
         run: |
           export GPG_TTY=$(tty)
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode | gpg --batch --import
@@ -91,7 +91,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
-        if: github.event.inputs.publishToMaven == true
+        if: github.event.inputs.publishToMaven == true || github.event_name == 'release'
         run: |
           ./gradlew publishToSonatype -Pversion=${{ steps.ci-release-create-outputs.outputs.version }} $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
           -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \


### PR DESCRIPTION
## Context
I am stupid — in #89 I set the release workflow's default for if Maven publishing should be done to false thinking that someone should explicitly check the box if they really wanted it. However, when the workflow is triggered by release publication, it will always skip Maven publishing, which is obviously not desired.
This can be fixed by either setting the default to true or letting the steps always run on a release event. I think the latter would be fine to preserve my original intent.
## Changes
- Ensure Maven publishing in release workflow always runs if the GitHub event is a release