### PR TITLE
Scope ownership endpoint updates

### DIFF
--- a/models/src/main/kotlin/io/provenance/api/models/p8e/tx/ChangeScopeOwnershipBatchRequest.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/p8e/tx/ChangeScopeOwnershipBatchRequest.kt
@@ -1,0 +1,14 @@
+package io.provenance.api.models.p8e.tx
+
+import io.provenance.api.models.account.AccountInfo
+import io.provenance.api.models.p8e.PermissionInfo
+import io.provenance.api.models.p8e.ProvenanceConfig
+import java.util.UUID
+
+data class ChangeScopeOwnershipBatchRequest(
+    val account: AccountInfo = AccountInfo(),
+    val provenanceConfig: ProvenanceConfig,
+    val scopeIds: List<UUID>,
+    val newValueOwner: String? = null,
+    val newDataAccess: PermissionInfo? = null,
+)

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/ChangeScopeOwnership.kt
@@ -32,7 +32,7 @@ class ChangeScopeOwnership(
 
         val signer = getSigner.execute(GetSignerRequest(args.uuid, args.request.account))
 
-        val messages = args.request.scopeIds.map {
+        val messages = args.request.scopeIds.distinct().map {
             val scopeResponse = provenance.getScope(args.request.provenanceConfig, it)
                 .takeIf { response -> response.scope.isSet() }
                 ?: throw NotFoundError("No scope found")

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipBatchRequestWrapper.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipBatchRequestWrapper.kt
@@ -1,0 +1,9 @@
+package io.provenance.api.domain.usecase.provenance.tx.scope.models
+
+import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipBatchRequest
+import java.util.UUID
+
+data class ChangeScopeOwnershipBatchRequestWrapper(
+    val uuid: UUID,
+    val request: ChangeScopeOwnershipBatchRequest,
+)

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipRequestWrapper.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/provenance/tx/scope/models/ChangeScopeOwnershipRequestWrapper.kt
@@ -1,9 +1,21 @@
 package io.provenance.api.domain.usecase.provenance.tx.scope.models
 
+import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipBatchRequest
 import io.provenance.api.models.p8e.tx.ChangeScopeOwnershipRequest
 import java.util.UUID
 
 data class ChangeScopeOwnershipRequestWrapper(
     val uuid: UUID,
     val request: ChangeScopeOwnershipRequest,
-)
+) {
+    fun toBatchWrapper() = ChangeScopeOwnershipBatchRequestWrapper(
+        uuid,
+        ChangeScopeOwnershipBatchRequest(
+            request.account,
+            request.provenanceConfig,
+            listOf(request.scopeId),
+            request.newValueOwner,
+            request.newDataAccess
+        )
+    )
+}

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceApi.kt
@@ -382,6 +382,9 @@ class ProvenanceApi {
                 GET("/query", handler::queryScope)
                 POST("/ownership", handler::changeScopeOwnership)
                 PATCH("/data", handler::updateDataAccess)
+                "/batch".nest {
+                    POST("/ownership", handler::changeScopeOwnershipBatch)
+                }
             }
             POST("/verify", handler::verifyAsset)
             PATCH("/permissions/authz", handler::updateAuthz)

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceHandler.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/provenance/ProvenanceHandler.kt
@@ -18,6 +18,7 @@ import io.provenance.api.domain.usecase.provenance.tx.permissions.authz.models.U
 import io.provenance.api.domain.usecase.provenance.tx.permissions.dataAccess.UpdateScopeDataAccess
 import io.provenance.api.domain.usecase.provenance.tx.permissions.dataAccess.models.UpdateScopeDataAccessRequestWrapper
 import io.provenance.api.domain.usecase.provenance.tx.scope.ChangeScopeOwnership
+import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipBatchRequestWrapper
 import io.provenance.api.domain.usecase.provenance.tx.scope.models.ChangeScopeOwnershipRequestWrapper
 import io.provenance.api.frameworks.web.SuccessResponses
 import io.provenance.api.frameworks.web.misc.foldToServerResponse
@@ -64,6 +65,15 @@ class ProvenanceHandler(
     suspend fun changeScopeOwnership(req: ServerRequest): ServerResponse = runCatching {
         changeScopeOwnership.execute(
             ChangeScopeOwnershipRequestWrapper(
+                req.getUser(),
+                req.awaitBody(),
+            ).toBatchWrapper()
+        )
+    }.foldToServerResponse()
+
+    suspend fun changeScopeOwnershipBatch(req: ServerRequest): ServerResponse = runCatching {
+        changeScopeOwnership.execute(
+            ChangeScopeOwnershipBatchRequestWrapper(
                 req.getUser(),
                 req.awaitBody(),
             )

--- a/service/src/test/kotlin/io/provenance/api/integration/tx/ChangeScopeOwnershipTest.kt
+++ b/service/src/test/kotlin/io/provenance/api/integration/tx/ChangeScopeOwnershipTest.kt
@@ -29,7 +29,7 @@ class ChangeScopeOwnershipTest(
                             newValueOwner = null,
                             newDataAccess = null,
                         )
-                    )
+                    ).toBatchWrapper()
                 )
             }.let { exception ->
                 exception.message shouldContain "Must request at least one change to the scope"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Allowing a batch variation of the scope ownership endpoint such that multiple scopes can be changed in the same transaction. This is intended to reduce the number of account sequence mismatch errors that is coming from provenance when many scope ownership changes are made on separate txs. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
