### PR TITLE
Updating release to allow maven to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           tags: ${{ steps.ci-release-create-outputs.outputs.tags }}
 
       - name: Install gpg secret key
-        if: github.event.inputs.publishToMaven == true || github.event_name == 'release'
+        if: inputs.publishToMaven || github.event_name == 'release'
         run: |
           export GPG_TTY=$(tty)
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode | gpg --batch --import
@@ -91,7 +91,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
-        if: github.event.inputs.publishToMaven == true || github.event_name == 'release'
+        if: inputs.publishToMaven || github.event_name == 'release'
         run: |
           ./gradlew publishToSonatype -Pversion=${{ steps.ci-release-create-outputs.outputs.version }} $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
           -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When manually triggering a workflow, the publish to maven step is always skipped despite having the value checked. I believe this is due to `github.events.inputs` context converting the value to a string and the check itself is comparing against a bool. Github documentation states: 

```
Note: The workflow will also receive the inputs in the github.event.inputs context. 
The information in the inputs context and github.event.inputs context is identical
 except that the inputs context preserves Boolean values as Booleans
 instead of converting them to strings.
```

So changing contexts should let us check the bool directly.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
