### PR TITLE
broadcast adjustments, synchronizing tx

### DIFF
--- a/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
@@ -5,6 +5,6 @@ import cosmos.tx.v1beta1.ServiceOuterClass
 data class ProvenanceConfig(
     val chainId: String,
     val nodeEndpoint: String,
-    val gasAdjustment: Double? = 1.2,
+    val gasAdjustment: Double? = 1.5,
     val broadcastMode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK
 )

--- a/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
@@ -5,6 +5,6 @@ import cosmos.tx.v1beta1.ServiceOuterClass
 data class ProvenanceConfig(
     val chainId: String,
     val nodeEndpoint: String,
-    val gasAdjustment: Double? = 1.5,
-    val broadcastMode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC
+    val gasAdjustment: Double? = 1.2,
+    val broadcastMode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Defaulting broadcast mode to `BROADCAST_MODE_BLOCK`, which should help with `sequence mismatch` errors.
- Synchronizing the tryAction execution block to force deterministic offsets. Previously, if two threads entered the method, it's possible they both could get an offset before knowing the outcome of the tx. Thus, if one failed it would guarantee a `sequence mismatch` 
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/p8e-cee-api/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Unit Test Results` in the comment section below once CI passes
