### PR TITLE
Bump loan-package-contracts version to v1.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val ProvenanceClient = "1.3.0"
     const val Unirest = "3.13.6"
     const val KmsConnector = "0.3.6"
-    const val LoanPackage = "1.0.2"
+    const val LoanPackage = "1.1.0"
     const val Grpc = "1.51.3"
     const val ProvenanceProto = "1.13.1"
     const val Reflections = "0.9.10"


### PR DESCRIPTION
## Context
Bumping the `loan-package-contracts` version to the latest release just made
## Changes
- Update `loan-package-contracts` contracts dependency version from `v1.0.2` to `v1.1.0`
  - See full changes [here](https://github.com/provenance-io/loan-package-contracts/compare/v1.0.2...v1.1.0)