### PR TITLE
Bump MAM to v1.1.3 & fix classpath issues with dependency

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val KotlinFaker = "1.7.1"
     const val SpringMockk = "3.0.1"
     const val Swagger = "1.6.2"
-    const val AssetModel = "1.1.1"
+    const val AssetModel = "1.1.3"
     const val P8eScope = "0.6.4"
     const val ProvenanceHdWallet = "0.1.15"
     const val ProvenanceClient = "1.3.0"

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
         Dependencies.Protobuf.JavaUtil,
         Dependencies.P8eScope.ContractProto,
         Dependencies.P8eScope.ContractBase,
-        Dependencies.Provenance.AssetModel,
         Dependencies.P8eScope.OsClient,
         Dependencies.Kotlin.CoroutinesReactor,
         Dependencies.Jackson.Databind,
@@ -24,6 +23,12 @@ dependencies {
         Dependencies.Provenance.KeyAccessLib,
     ).forEach { dep ->
         dep.implementation(this)
+    }
+
+    implementation(Dependencies.Provenance.AssetModel.toDependencyNotation()) {
+        version {
+            strictly(Versions.AssetModel)
+        }
     }
 }
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
         Dependencies.P8eScope.OsClient,
         Dependencies.P8eScope.Sdk,
         Dependencies.P8eScope.Util,
-        Dependencies.Provenance.AssetModel,
         Dependencies.Provenance.KeyAccessLib,
         Dependencies.Provenance.HdWallet.HdWallet,
         Dependencies.Provenance.HdWallet.HdWalletBip39,
@@ -69,6 +68,12 @@ dependencies {
 
     ).forEach { dep ->
         dep.implementation(this)
+    }
+
+    implementation(Dependencies.Provenance.AssetModel.toDependencyNotation()) {
+        version {
+            strictly(Versions.AssetModel)
+        }
     }
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")


### PR DESCRIPTION
## Context
While bumping the https://github.com/provenance-io/metadata-asset-model/ version, also fixing issues with it being pulled in as a transitive dependency that cause an IDE to not be able to resolve its imports correctly
## Changes
- Update `metadata-asset-model` from `v1.1.1` to `v1.1.3`
- Force resolution of `metadata-asset-model` dependency version in both subprojects