### PR TITLE
Fix release workflow trigger not tagging Docker image as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Set Image Details
         id: ci-release-create-outputs
+        shell: bash
         run: |
           VERSION=$( echo ${{ github.event.release.tag_name }} | sed -e 's/^v//' )
           if [ "$VERSION" == "" ] ; then
@@ -57,7 +58,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
           TAG_DOCKER_IMAGE_AS_LATEST=false
-          if [ "${{ inputs.tagAsLatest }}" == "true" ] || [ ("${{github.event_name}}" == "release" && "${{github.event.release.prerelease}}" == "false") ] ; then
+          if [[ "${{ inputs.tagAsLatest }}" == "true" || ("${{github.event_name}}" == "release" && "${{github.event.release.prerelease}}" == "false") ]] ; then
             TAG_DOCKER_IMAGE_AS_LATEST=true
           fi
           echo "tagAsLatest=${TAG_DOCKER_IMAGE_AS_LATEST}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,18 @@ jobs:
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+          TAG_DOCKER_IMAGE_AS_LATEST=false
+          if [ "${{ inputs.tagAsLatest }}" == "true" || ("${{github.event_name}}" == "release" && "${{github.event.release.prerelease}}" == "false") ] ; then
+            TAG_DOCKER_IMAGE_AS_LATEST=true
+          fi
+          echo "tagAsLatest=${TAG_DOCKER_IMAGE_AS_LATEST}" >> $GITHUB_OUTPUT
+
       - name: Build and Push Docker Image
         env:
           JIB_AUTH_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           JIB_AUTH_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKER_IMAGE_NAME: provenanceio/p8e-cee-api:${{ steps.ci-release-create-outputs.outputs.version }}
-          TAG_DOCKER_IMAGE_AS_LATEST: ${{ github.event.inputs.tagAsLatest }}
+          TAG_DOCKER_IMAGE_AS_LATEST: ${{ steps.ci-release-create-outputs.outputs.tagAsLatest }}
         run: ./gradlew :service:jib -Djib.console=plain -Pversion=${VERSION}
 
       - name: Install gpg secret key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
           TAG_DOCKER_IMAGE_AS_LATEST=false
-          if [ "${{ inputs.tagAsLatest }}" == "true" || ("${{github.event_name}}" == "release" && "${{github.event.release.prerelease}}" == "false") ] ; then
+          if [ "${{ inputs.tagAsLatest }}" == "true" ] || [ ("${{github.event_name}}" == "release" && "${{github.event.release.prerelease}}" == "false") ] ; then
             TAG_DOCKER_IMAGE_AS_LATEST=true
           fi
           echo "tagAsLatest=${TAG_DOCKER_IMAGE_AS_LATEST}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixing an issue introduced in #122 where the publishing of a GitHub release does not tag the Docker image that is subsequently published with `latest`.