### PR TITLE
Address warnings in scripts, improve package install, fix outdated paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ The `p8e-cee-api` allows for operations against the encrypted object store, with
 The [Asset Originator's Guide](https://docs.provenance.io/integrating/asset-originators-guide) provides contextual support for the varied use cases supported by this API. Having a fundamental understanding of the Provenance Blockchain is recommended.
 
 ## Local Setup
-To run this service locally, be sure to have [Docker](https://www.docker.com/) and [Vault by Hashicorp](https://www.vaultproject.io/) installed:
+To run this service locally, be sure to have [Docker](https://www.docker.com/) installed:
 
 ```
 brew install docker
 ```
-
+You can also install [Vault](https://www.vaultproject.io/) if you wish to use a local installation over the provided Docker container:
 ```
 brew tap hashicorp/tap
 brew install hashicorp/tap/vault
 ```
-If you plan on running smart contracts for asset classification you'll need the following:
+If you plan on running smart contracts for asset classification, you may need the following packages:
 ```
 brew install rust
 brew install jq

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The default configuration assumes that the following ports are available:
 |     Vault      |       8200        |
 |   Provenance   | 1317, 9090, 26657 |
 
-If any are taken on your local machine, feel free to update the default values in the `/service/docker/dependencies.yaml` file and associated `/service/docker/*.env` files.
+If any are taken on your local machine, feel free to update the default values in the `/service/local-docker/dependencies.yaml` file and associated `/service/local-docker/*.env` files.
 
 Once ready, all you need to do is run the included docker setup script from the root directory:
 
@@ -95,4 +95,4 @@ For example:
 ./dc.sh -p ../../provenance-io/loan-package-contracts -v 0.3.2 publish
 ```
 
-Note: This convenience method uses preset environment variables found in `/service/docker/bootstrap.env` and assumes the address used to sign the transactions associated with publishing the contracts is listed in the genesis block (`/service/docker/prov-init/config/genesis.json`).
+Note: This convenience method uses preset environment variables found in `/service/local-docker/bootstrap.env` and assumes the address used to sign the transactions associated with publishing the contracts is listed in the genesis block (`/service/local-docker/prov-init/config/genesis.json`).

--- a/dc.sh
+++ b/dc.sh
@@ -20,42 +20,42 @@ while getopts 'p:v:c' OPTION; do
       ;;
   esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND -1))"
 
 function up {
-  docker-compose -p p8e-contract-execution-environment -f service/docker/dependencies.yaml up --build -d
+  docker-compose -p p8e-contract-execution-environment -f service/local-docker/dependencies.yaml up --build -d
 
   sleep 2
   export VAULT_ADDR="http://127.0.0.1:8200"
   SECRET_PATH=kv2_originations
-  sh service/docker/vault/init-and-unseal.sh $VAULT_ADDR $SECRET_PATH
+  sh service/local-docker/vault/init-and-unseal.sh $VAULT_ADDR $SECRET_PATH
 
   until vault status; do echo "Awaiting vault to be unsealed..."; sleep 5; done
 
   # local-originator
-  cat service/docker/vault/secrets/local-originator.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000001 - > /dev/null
-  cat service/docker/vault/secrets/local-originator.json | vault kv put $SECRET_PATH/originators/tp1qy2mqx5x22a400pgd5p6u7mq9shxzvh767jar0 - > /dev/null
+  < service/local-docker/vault/secrets/local-originator.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000001 - > /dev/null
+  < service/local-docker/vault/secrets/local-originator.json vault kv put $SECRET_PATH/originators/tp1qy2mqx5x22a400pgd5p6u7mq9shxzvh767jar0 - > /dev/null
   # local-servicer
-  cat service/docker/vault/secrets/local-servicer.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000002 - > /dev/null
-  cat service/docker/vault/secrets/local-servicer.json | vault kv put $SECRET_PATH/originators/tp1xr3wfqzlcz469wkex5c3ylaq8pq97crhsg57gd - > /dev/null
+  < service/local-docker/vault/secrets/local-servicer.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000002 - > /dev/null
+  < service/local-docker/vault/secrets/local-servicer.json vault kv put $SECRET_PATH/originators/tp1xr3wfqzlcz469wkex5c3ylaq8pq97crhsg57gd - > /dev/null
   # local-dart
-  cat service/docker/vault/secrets/local-dart.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000003 - > /dev/null
-  cat service/docker/vault/secrets/local-dart.json | vault kv put $SECRET_PATH/originators/tp1s2c62ke0mmwhqxguf7e2pt6e98yq38m4atwhwl - > /dev/null
+  < service/local-docker/vault/secrets/local-dart.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000003 - > /dev/null
+  < service/local-docker/vault/secrets/local-dart.json vault kv put $SECRET_PATH/originators/tp1s2c62ke0mmwhqxguf7e2pt6e98yq38m4atwhwl - > /dev/null
   # local-portfolio-manager
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000004 - > /dev/null
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/tp1mryqzguyelef5dae7k6l22tnls93cvrc60tjdc - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000004 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/tp1mryqzguyelef5dae7k6l22tnls93cvrc60tjdc - > /dev/null
   # local-controller-a
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000005 - > /dev/null
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/tp138jtpz5zxa6yc33s0fk2jy9vahqcuvvtwnrzge - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000005 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/tp138jtpz5zxa6yc33s0fk2jy9vahqcuvvtwnrzge - > /dev/null
   # local-controller-b
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000006 - > /dev/null
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/tp1pz4tt4j802j2y3avs5mwy9uyyxtx7k5r8qlehw - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000006 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/tp1pz4tt4j802j2y3avs5mwy9uyyxtx7k5r8qlehw - > /dev/null
   # local-validator
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000007 - > /dev/null
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/tp1he6rfnxyx2ssqyknq4ayzf5j46dp29pqt6z708 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000007 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/tp1he6rfnxyx2ssqyknq4ayzf5j46dp29pqt6z708 - > /dev/null
   # local-investor
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000008 - > /dev/null
-  cat service/docker/vault/secrets/local-portfolio-manager.json | vault kv put $SECRET_PATH/originators/tp1f99dgtxxjmgczjsuc48utq4lkk0uhx6eqfqju0 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/00000000-0000-0000-0000-000000000008 - > /dev/null
+  < service/local-docker/vault/secrets/local-portfolio-manager.json vault kv put $SECRET_PATH/originators/tp1f99dgtxxjmgczjsuc48utq4lkk0uhx6eqfqju0 - > /dev/null
 
   docker ps -a
 
@@ -66,21 +66,23 @@ function up {
 }
 
 function publish() {
+    set -e
     if [ -z ${PATH_TO_CONTRACTS+x} ]; then
         echo "Provide a valid path to the contracts directory you wish to publish using the -p argument."
         exit 1
     fi
 
-    if [ -z ${CONTRACTS_VERSION} ]; then
+    if [ -z "${CONTRACTS_VERSION}" ]; then
         echo "Provide a valid version string you wish to publish the contracts as using the -v argument."
         exit 1
     fi
 
-   source ./service/docker/bootstrap.env
-   export FULL_PATH=$(realpath $PATH_TO_CONTRACTS)
+   source ./service/local-docker/bootstrap.env
+   FULL_PATH=$(realpath "$PATH_TO_CONTRACTS")
+   export FULL_PATH
 
     if [[ -d "$FULL_PATH" ]]; then
-        pushd $PATH_TO_CONTRACTS > /dev/null
+        pushd "$PATH_TO_CONTRACTS" > /dev/null
         ./gradlew p8eClean p8eCheck p8eBootstrap --info && ./gradlew publishToMavenLocal -Pversion="$CONTRACTS_VERSION" -xsignMavenPublication --info
         popd > /dev/null
     else
@@ -90,7 +92,7 @@ function publish() {
 }
 
 function down {
-  docker-compose -p p8e-contract-execution-environment -f service/docker/dependencies.yaml down
+  docker-compose -p p8e-contract-execution-environment -f service/local-docker/dependencies.yaml down
   docker volume prune -f
 }
 
@@ -100,19 +102,22 @@ function bounce {
 }
 
 function build_classification() {
+    set -e
+
     if [ -z ${PATH_TO_CONTRACTS+x} ]; then
         echo "Provide a valid path to the smart contracts directory you wish to store on provenance using the -p argument."
         exit 1
     fi
 
-    export FULL_PATH=$(realpath $PATH_TO_CONTRACTS)
+    FULL_PATH=$(realpath "$PATH_TO_CONTRACTS")
+    export FULL_PATH
 
     if [[ -d "$PATH_TO_CONTRACTS" ]]; then
-        pushd $PATH_TO_CONTRACTS > /dev/null
+        pushd "$PATH_TO_CONTRACTS" > /dev/null
         cargo build
         make optimize
         popd > /dev/null
-        cp $PATH_TO_CONTRACTS/artifacts/asset_classification_smart_contract.wasm service/docker/prov-init/contracts/asset_classification_smart_contract.wasm
+        cp "$PATH_TO_CONTRACTS"/artifacts/asset_classification_smart_contract.wasm service/local-docker/prov-init/contracts/asset_classification_smart_contract.wasm
     else
         echo "Invalid path. Provide a valid path to the contracts directory you wish to publish."
         exit 1
@@ -120,11 +125,30 @@ function build_classification() {
 }
 
 function setup() {
-      which -s docker || brew install docker
-      which -s vault || { brew tap hashicorp/tap; brew install hashicorp/tap/vault; }
-      which -s rust || brew install rust
-      which -s jq || brew install jq
-      brew install coreutils
+      if ! command -v brew &> /dev/null
+      then
+          echo "This script can only install the prerequisite packages via Homebrew, which was not found in the path. Please manually install the packages instead."
+          exit 1
+      else
+          brew install coreutils
+      fi
+      if ! command -v docker &> /dev/null
+      then
+          brew install docker
+      fi
+      if ! command -v vault &> /dev/null
+      then
+          brew tap hashicorp/tap
+          brew install hashicorp/tap/vault
+      fi
+      if ! command -v rust &> /dev/null
+      then
+          brew install rust
+      fi
+      if ! command -v jq &> /dev/null
+      then
+          brew install jq
+      fi
 }
 
 function upload_classification_contract() {
@@ -141,13 +165,13 @@ function upload_classification_contract() {
                      --output json \
                      --yes)
 
-    code_id=$(echo $upload | jq -r '.logs[] | select(.msg_index == 0) | .events[] | select(.type == "store_code") | .attributes[0].value')
+    code_id=$(echo "$upload" | jq -r '.logs[] | select(.msg_index == 0) | .events[] | select(.type == "store_code") | .attributes[0].value')
     echo "Upload complete. Code id: $code_id"
-    instantiate=$(docker exec provenance provenanced tx wasm instantiate $code_id \
+    instantiate=$(docker exec provenance provenanced tx wasm instantiate "$code_id" \
                        '{
                          "base_contract_name": "assetclassificationalias.pb",
                          "bind_base_name": true,
-                         "asset_definitions": '"$(cat service/docker/prov-init/contracts/asset_definitions.json)"',
+                         "asset_definitions": '"$(cat service/local-docker/prov-init/contracts/asset_definitions.json)"',
                          "is_test": true
                        }' \
                        --admin "tp1v5d9uek3qwqh25yrchj20mkgrksdfyyxhnsdag" \
@@ -162,7 +186,7 @@ function upload_classification_contract() {
                        --output json \
                        --yes | jq)
 
-    contract_address=$(echo $instantiate | jq '.logs[] | select(.msg_index == 0) | .events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
+    contract_address=$(echo "$instantiate" | jq '.logs[] | select(.msg_index == 0) | .events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
     echo "Asset classification contract fully setup! contract address: $contract_address"
 }
 

--- a/service/local-docker/bootstrap.env
+++ b/service/local-docker/bootstrap.env
@@ -1,13 +1,13 @@
 # Export a mnemonic, private key, and address that can be used for provenance transactions and contract execution
 
-export CHAINCODE_MNEMONIC_1="stable payment cliff fault abuse clinic bus belt film then forward world goose bring picnic rich special brush basic lamp window coral worry change"
-export PRIVATE_KEY_1="0A201AD27E627DD0A6A5816D293C41DF801D3E7BA868EEC0F433FDA581D71E38016E"
-export ADDRESS_1="tp1s2c62ke0mmwhqxguf7e2pt6e98yq38m4atwhwl"
+CHAINCODE_MNEMONIC_1="stable payment cliff fault abuse clinic bus belt film then forward world goose bring picnic rich special brush basic lamp window coral worry change"
+PRIVATE_KEY_1="0A201AD27E627DD0A6A5816D293C41DF801D3E7BA868EEC0F433FDA581D71E38016E"
+ADDRESS_1="tp1s2c62ke0mmwhqxguf7e2pt6e98yq38m4atwhwl"
 
 # p8e contract bootstrapping - signing and encryption keys are the same and match the private key above
 
-export SIGNING_PRIVATE_KEY=$PRIVATE_KEY_1
-export ENCRYPTION_PRIVATE_KEY=$PRIVATE_KEY_1
-export OS_GRPC_URL="grpc://localhost:5001"
-export PROVENANCE_GRPC_URL="grpc://localhost:9090"
-export CHAIN_ID="chain-local"
+SIGNING_PRIVATE_KEY=$PRIVATE_KEY_1
+ENCRYPTION_PRIVATE_KEY=$PRIVATE_KEY_1
+OS_GRPC_URL="grpc://localhost:5001"
+PROVENANCE_GRPC_URL="grpc://localhost:9090"
+CHAIN_ID="chain-local"

--- a/service/local-docker/dependencies.yaml
+++ b/service/local-docker/dependencies.yaml
@@ -69,14 +69,14 @@ services:
 
     vault:
         image: hashicorp/vault:1.14.4
-        container_name: vault-cee
+        container_name: ${VAULT_DOCKER_CONTAINER_NAME:-vault-cee}
         networks:
             - p8e-network
         ports:
             - "8200:8200"
         restart: always
         environment:
-            - VAULT_DEV_ROOT_TOKEN_ID=root
+            - VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN:-root}
             - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
         cap_add:
             - IPC_LOCK

--- a/service/local-docker/dependencies.yaml
+++ b/service/local-docker/dependencies.yaml
@@ -51,7 +51,7 @@ services:
             - ./object-store-2:/mnt/data
 
     provenance:
-        image: provenanceio/provenance:v1.13.1 # TODO: Update version to latest
+        image: provenanceio/provenance:v1.16.0
         container_name: provenance
         command: bash -c "cp -rn /home/provenance_seed/* /provenance && /usr/bin/provenanced -t --home /provenance start"
         networks:
@@ -68,7 +68,7 @@ services:
             - provenance:/provenance
 
     vault:
-        image: hashicorp/vault:latest # TODO: Pin version
+        image: hashicorp/vault:1.14.4
         container_name: vault-cee
         networks:
             - p8e-network

--- a/service/local-docker/vault/.env
+++ b/service/local-docker/vault/.env
@@ -1,0 +1,4 @@
+SECRET_PATH=kv2_originations
+VAULT_ADDR=http://127.0.0.1:8200
+VAULT_DOCKER_CONTAINER_NAME=vault-cee
+VAULT_TOKEN=root

--- a/service/local-docker/vault/init-and-unseal.sh
+++ b/service/local-docker/vault/init-and-unseal.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 set -e
 
-export VAULT_ADDR=$1
-export SECRET_PATH=$2
-export VAULT_TOKEN=root
+source ./service/local-docker/vault/.env
 
-echo "root" | tee ~/.vault-token
+VAULT_BINARY="docker exec -i --env-file ./service/local-docker/vault/.env $VAULT_DOCKER_CONTAINER_NAME vault"
+if ! docker exec -i "$VAULT_DOCKER_CONTAINER_NAME" vault --help 2>/dev/null 1>&2
+then
+    echo "No Docker container named '$VAULT_DOCKER_CONTAINER_NAME' was found running..."
+    if ! command -v vault &> /dev/null
+    then
+        echo "Vault must be running under an appropriately named Docker container or local machine installation"
+        exit 1
+    else
+        echo "Found a local installation of Vault to use instead."
+        VAULT_BINARY="vault"
+    fi
+fi
+
+echo "$VAULT_TOKEN" | tee ~/.vault-token
 
 printf "\nEnabling KV store..\n\n"
-vault secrets enable -version=2 -path=$SECRET_PATH kv
+$VAULT_BINARY secrets enable -version=2 -path="$SECRET_PATH" kv
 printf "\nView/edit secret at %s/ui/vault/secrets/%s/list\n" "${VAULT_ADDR}" "${SECRET_PATH}"
-printf "Log in using token: root"
+printf "Log in using token: %s\n" "$VAULT_TOKEN"
 
 exit 0;

--- a/service/src/test/resources/dependencies.yaml
+++ b/service/src/test/resources/dependencies.yaml
@@ -50,7 +50,7 @@ services:
             - ./object-store:/mnt/data
 
     provenance:
-        image: provenanceio/provenance:v1.13.1 # TODO: Update version
+        image: provenanceio/provenance:v1.16.0
         command: bash -c "cp -rn /home/provenance_seed/* /provenance && /usr/bin/provenanced -t --home /provenance start"
         networks:
             - p8e-network-test
@@ -66,7 +66,7 @@ services:
             - provenance:/provenance
 
     vault:
-        image: hashicorp/vault:latest # TODO: Pin version
+        image: hashicorp/vault:1.14.4
         networks:
             - p8e-network-test
         ports:


### PR DESCRIPTION
## Context
Updating inconsistencies in the local environment setup & instructions and updating some Docker image versions in both the local environment and the integration tests.
## Changes
- Fix outdated paths to `service/docker` folder which was renamed in #122
- Address ShellCheck warnings in the local environment setup script files
- Update the Provenance Docker image versions to `v1.16.0`
- Update Vault Docker image versions