### PR TITLE
feat: Add support for specifying a timeout height for any transaction

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.22"
 kotlin_coroutines = "1.6.4"
-assetClassification = "3.8.1"
+assetClassification = "3.9.0"
 bouncyCastle = "1.70"
 detekt = "1.18.1"
 grpc = "1.51.3"

--- a/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
+++ b/models/src/main/kotlin/io/provenance/api/models/p8e/ProvenanceConfig.kt
@@ -8,4 +8,5 @@ data class ProvenanceConfig(
     val gasAdjustment: Double? = 1.5,
     val broadcastMode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK,
     val feeGranter: String? = null,
+    val timeoutHeight: Long? = null,
 )

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/ProvenanceService.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/ProvenanceService.kt
@@ -79,7 +79,11 @@ class ProvenanceService : Provenance {
                 sequenceOffset = offset,
             )
 
-            val tx = messages.toTxBody(pbClient)
+            val tx = if (config.timeoutHeight !== null) {
+                messages.toTxBody(timeoutHeight = config.timeoutHeight!!)
+            } else {
+                messages.toTxBody(pbClient)
+            }
 
             val result = pbClient.estimateAndBroadcastTx(
                 txBody = tx,
@@ -123,7 +127,8 @@ class ProvenanceService : Provenance {
                 options = BroadcastOptions(
                     broadcastMode = config.broadcastMode,
                     sequenceOffset = offset,
-                    baseAccount = account
+                    baseAccount = account,
+                    timeoutHeight = config.timeoutHeight,
                 )
             )
         }.txResponse.toTxResponse()
@@ -142,7 +147,8 @@ class ProvenanceService : Provenance {
                 options = BroadcastOptions(
                     broadcastMode = config.broadcastMode,
                     sequenceOffset = offset,
-                    baseAccount = account
+                    baseAccount = account,
+                    timeoutHeight = config.timeoutHeight,
                 )
             )
         }.txResponse.toTxResponse()

--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/extensions/ProvenanceExtensions.kt
@@ -54,6 +54,12 @@ fun Iterable<Any>.toTxBody(pbClient: PbClient) =
         .addAllMessages(this)
         .build()
 
+internal fun Iterable<Any>.toTxBody(timeoutHeight: Long): TxOuterClass.TxBody =
+    TxOuterClass.TxBody.newBuilder()
+        .setTimeoutHeight(timeoutHeight)
+        .addAllMessages(this)
+        .build()
+
 fun Any.toTxBody(pbClient: PbClient) =
     TxOuterClass.TxBody.newBuilder()
         .setTimeoutHeight(getCurrentHeight(pbClient) + 12L)


### PR DESCRIPTION
## Context
Follow-up to #131 to add support for specifying a chain height at which a transaction should time out.
## Changes
- Add new optional field `timeoutHeight` to request inputs
- Bump `tech.figure.classification.asset` dependency versions from `3.8.1` to latest, `3.9.0`, to enable [support for passing timeout height through to asset classification requests](https://github.com/FigureTechnologies/asset-classification-libs/pull/137)