### PR TITLE
Fix scope requests no longer including the request

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/frameworks/provenance/ProvenanceService.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/provenance/ProvenanceService.kt
@@ -99,14 +99,13 @@ class ProvenanceService : Provenance {
     override fun getScope(config: ProvenanceConfig, scopeUuid: UUID, height: Long?): ScopeResponse =
         PbClient(config.chainId, URI(config.nodeEndpoint), GasEstimationMethod.MSG_FEE_CALCULATION).use { pbClient ->
             pbClient.metadataClient.scope(
-                ScopeRequest.newBuilder()
-                    .setScopeId(scopeUuid.toString())
-                    .setIncludeRecords(true)
-                    .setIncludeSessions(true)
-                    .also {
-                        height?.let { pbClient.metadataClient.addBlockHeight(it.toString()) }
-                    }
-                    .build()
+                ScopeRequest.newBuilder().apply {
+                    scopeId = scopeUuid.toString()
+                    includeRecords = true
+                    includeSessions = true
+                    includeRequest = true
+                    height?.let { pbClient.metadataClient.addBlockHeight(it.toString()) }
+                }.build()
             )
         }
 


### PR DESCRIPTION
## Context
#132 broke the `GET /external/api/v1/p8e/scope/query` endpoint due to apparently no longer including the request in a `ScopeRequest` or `SessionRequest` by default.
## Changes
- Explicitly set `includeRequest` to `true` in all `ScopeRequest` messages