### PR TITLE
Log class name on cast failure when storing files in an object store

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -10,6 +10,7 @@ import io.provenance.api.models.account.AccountInfo
 import io.provenance.api.models.eos.store.StoreProtoResponse
 import io.provenance.api.models.p8e.PermissionInfo
 import io.provenance.api.util.awaitAllBytes
+import io.provenance.api.util.buildLogMessage
 import io.provenance.entity.KeyType
 import io.provenance.scope.util.toUuid
 import kotlinx.coroutines.reactor.awaitSingle
@@ -85,7 +86,12 @@ class StoreFile(
 
     private inline fun <reified T> Map<String, Part>.getAsType(key: String): T =
         T::class.java.cast(get(key))
-            ?: throw IllegalArgumentException("Failed to retrieve and cast provided argument.")
+            ?: throw IllegalArgumentException(
+                buildLogMessage(
+                    "Failed to retrieve and cast provided argument",
+                    "javaClass" to T::class.java.name,
+                )
+            )
 
     data class Args(
         val account: AccountInfo?,

--- a/service/src/main/kotlin/io/provenance/api/util/Debug.kt
+++ b/service/src/main/kotlin/io/provenance/api/util/Debug.kt
@@ -11,3 +11,14 @@ private val debugObjectMapper by lazy {
 }
 
 fun Any.toPrettyJson(): String = debugObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this)
+
+fun buildLogMessage(message: String, args: List<Pair<String, Any?>>): String =
+    args.joinToString(
+        separator = ", ",
+        prefix = "[",
+        postfix = "]"
+    ) { "${it.first}=${it.second}" }.let { argString ->
+        "$message $argString".trim()
+    }
+
+fun buildLogMessage(message: String, vararg args: Pair<String, Any?>): String = buildLogMessage(message, args.toList())


### PR DESCRIPTION
Adding the name of the class that failed to cast when attempting to store a file in an object store, to assist in debugging failed requests.