### PR TITLE
fix: More thoroughly clean up temp files from EOS uploads

### DIFF
--- a/service/src/main/kotlin/io/provenance/api/domain/objectStore/ObjectStore.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/objectStore/ObjectStore.kt
@@ -2,9 +2,25 @@ package io.provenance.api.domain.objectStore
 
 import io.provenance.api.models.eos.store.StoreProtoResponse
 import io.provenance.scope.encryption.model.KeyRef
+import java.io.InputStream
 import java.security.PublicKey
 
 interface ObjectStore {
     fun <T> retrieveAndDecrypt(client: T, hash: String, keyRef: KeyRef): ByteArray
     fun <T> store(client: T, message: ByteArray, keyRef: KeyRef, additionalAudiences: Set<PublicKey>, type: String?): StoreProtoResponse
+
+    /**
+     * Streams [contentLength] bytes from [message] to the object store without buffering the whole
+     * payload in memory. Only supported for direct object-store clients (not the gateway); the
+     * caller is responsible for closing [message]. This is the memory-safe path for large raw-byte
+     * uploads where the payload is already spilled to a temporary file on disk.
+     */
+    fun <T> store(
+        client: T,
+        message: InputStream,
+        contentLength: Long,
+        keyRef: KeyRef,
+        additionalAudiences: Set<PublicKey>,
+        type: String?,
+    ): StoreProtoResponse
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -94,10 +94,12 @@ class StoreFile(
     }
 
     /*
-     * Spills the part to a dedicated temp file, streams it to the object store, then always removes
-     * that temp file. The reader may already have spilled the part to disk, but we transfer to our
-     * own file so ownership and cleanup are unambiguous (the reader-owned file is deleted separately
-     * via deleteAllFileParts()).
+     * Materializes ("Spills") the part to a dedicated temp file, streams it to the object store, then always
+     * removes that temp file. Transferring to our own file (rather than reading the part's reactive
+     * content() into memory) lets us hand `OsClient.put` a plain InputStream together with an
+     * authoritative content length taken from `Files.size()`, the real number of bytes on disk —
+     * not a client-supplied per-part Content-Length header, which multipart parts frequently omit.
+     * The reader-owned spill file is cleaned up separately via deleteAllFileParts().
      */
     private suspend fun streamRawBytes(params: Args, keyRef: KeyRef): StoreProtoResponse {
         val destination = Files.createTempFile("p8e-cee-stream-", ".upload")

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreFile.kt
@@ -6,13 +6,17 @@ import io.provenance.api.domain.usecase.common.originator.EntityManager
 import io.provenance.api.domain.usecase.common.originator.models.KeyManagementConfigWrapper
 import io.provenance.api.domain.usecase.objectStore.store.models.StoreFileRequestWrapper
 import io.provenance.api.domain.usecase.objectStore.store.models.StoreObjectRequest
+import io.provenance.api.domain.usecase.objectStore.store.models.StoreObjectStreamRequest
 import io.provenance.api.models.account.AccountInfo
 import io.provenance.api.models.eos.store.StoreProtoResponse
 import io.provenance.api.models.p8e.PermissionInfo
 import io.provenance.api.util.awaitAllBytes
 import io.provenance.api.util.buildLogMessage
+import io.provenance.api.util.transferToPath
 import io.provenance.entity.KeyType
+import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.util.toUuid
+import java.nio.file.Files
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactor.awaitSingle
@@ -21,6 +25,7 @@ import org.springframework.http.codec.multipart.FilePart
 import org.springframework.http.codec.multipart.FormFieldPart
 import org.springframework.http.codec.multipart.Part
 import org.springframework.stereotype.Component
+import org.springframework.util.MultiValueMap
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.proto.util.FileNFT
 import tech.figure.proto.util.toProtoAny
@@ -46,40 +51,86 @@ class StoreFile(
         }
 
     private suspend fun store(args: StoreFileRequestWrapper): StoreProtoResponse {
-        val (account, permissions, objectStoreAddress, storeRawBytes, id, file, type) = getParams(args.request)
-        val entity = entityManager.getEntity(KeyManagementConfigWrapper(args.entity.id, account?.keyManagementConfig))
+        val params = getParams(args.request)
+        val entity = entityManager.getEntity(KeyManagementConfigWrapper(args.entity.id, params.account?.keyManagementConfig))
+        val keyRef = entity.getKeyRef(KeyType.ENCRYPTION)
 
-        return file.awaitAllBytes().map { bytes ->
+        /*
+         * Fast path for large raw uploads: when the caller wants the bytes stored verbatim (no Asset
+         * proto wrapping) and is not going through the gateway, stream the file straight from disk to
+         * the object store. This avoids loading the entire (potentially ~1GB) payload into a heap
+         * ByteArray, which is the dominant driver of the OutOfMemory errors on this endpoint. The
+         * proto-wrapping and gateway paths inherently need the bytes in memory and are left unchanged.
+         */
+        if (params.storeRawBytes && !args.useObjectStoreGateway) {
+            return streamRawBytes(params, keyRef)
+        }
+
+        return params.file.awaitAllBytes().map { bytes ->
             storeObject.executeBlocking(
                 StoreObjectRequest(
-                    if (!storeRawBytes)
+                    if (!params.storeRawBytes) {
                         Asset.newBuilder().also {
-                            it.id = id.toUuid().toProtoUUID()
+                            it.id = params.id.toUuid().toProtoUUID()
                             it.type = FileNFT.ASSET_TYPE
-                            it.description = file.filename()
-                            it.putKv(FileNFT.KEY_FILENAME, file.filename().toProtoAny())
+                            it.description = params.file.filename()
+                            it.putKv(FileNFT.KEY_FILENAME, params.file.filename().toProtoAny())
                             it.putKv(FileNFT.KEY_BYTES, bytes.toProtoAny())
                             it.putKv(FileNFT.KEY_SIZE, bytes.size.toString().toProtoAny())
-                            it.putKv(FileNFT.KEY_CONTENT_TYPE, file.headers().contentType.toString().toProtoAny())
-                        }.build().toByteArray() else bytes,
-                    type,
-                    objectStoreAddress,
+                            it.putKv(FileNFT.KEY_CONTENT_TYPE, params.file.headers().contentType.toString().toProtoAny())
+                        }.build().toByteArray()
+                    } else {
+                        bytes
+                    },
+                    params.type,
+                    params.objectStoreAddress,
                     args.useObjectStoreGateway,
-                    entity.getKeyRef(KeyType.ENCRYPTION),
-                    permissions,
-                    account ?: AccountInfo()
+                    keyRef,
+                    params.permissions,
+                    params.account ?: AccountInfo()
                 )
             )
         }.awaitSingle()
+    }
+
+    /*
+     * Spills the part to a dedicated temp file, streams it to the object store, then always removes
+     * that temp file. The reader may already have spilled the part to disk, but we transfer to our
+     * own file so ownership and cleanup are unambiguous (the reader-owned file is deleted separately
+     * via deleteAllFileParts()).
+     */
+    private suspend fun streamRawBytes(params: Args, keyRef: KeyRef): StoreProtoResponse {
+        val destination = Files.createTempFile("p8e-cee-stream-", ".upload")
+        return try {
+            params.file.transferToPath(destination).awaitSingle()
+            storeObject.executeStreaming(
+                StoreObjectStreamRequest(
+                    destination,
+                    Files.size(destination),
+                    params.type,
+                    params.objectStoreAddress,
+                    keyRef,
+                    params.permissions,
+                    params.account ?: AccountInfo()
+                )
+            )
+        } finally {
+            withContext(NonCancellable) {
+                runCatching { Files.deleteIfExists(destination) }
+            }
+        }
     }
 
     /**
      * Deletes the temporary file backing every [FilePart] in the request, ignoring parts that were
      * kept in memory or already removed. Errors are swallowed so cleanup never masks the original
      * outcome of the request.
+     *
+     * Iterates every value across all field names (not the single-value view) so that duplicate
+     * parts sharing a field name -- which the reader still spills to disk -- are also cleaned up.
      */
-    private suspend fun Map<String, Part>.deleteAllFileParts() {
-        val fileParts = values.filterIsInstance<FilePart>()
+    private suspend fun MultiValueMap<String, Part>.deleteAllFileParts() {
+        val fileParts = values.flatten().filterIsInstance<FilePart>()
         if (fileParts.isEmpty()) {
             return
         }
@@ -95,12 +146,12 @@ class StoreFile(
         }
     }
 
-    private fun getParams(request: Map<String, Part>): Args {
+    private fun getParams(request: MultiValueMap<String, Part>): Args {
         var permissions: PermissionInfo? = null
         var account: AccountInfo? = null
         var type: String? = null
 
-        request["account"]?.let {
+        request.getFirst("account")?.let {
             account = Gson().fromJson((it as FormFieldPart).value(), AccountInfo::class.java)
         }
 
@@ -108,11 +159,11 @@ class StoreFile(
             throw IllegalArgumentException("Request must provide the 'id' field for the file")
         }
 
-        request["permissions"]?.let {
+        request.getFirst("permissions")?.let {
             permissions = Gson().fromJson((it as FormFieldPart).value(), PermissionInfo::class.java)
         }
 
-        request["type"]?.let {
+        request.getFirst("type")?.let {
             type = request.getAsType<FormFieldPart>("type").value()
         }
 
@@ -123,8 +174,8 @@ class StoreFile(
         return Args(account, permissions, objectStoreAddress, storeRawBytes, id, file, type)
     }
 
-    private inline fun <reified T> Map<String, Part>.getAsType(key: String): T =
-        T::class.java.cast(get(key))
+    private inline fun <reified T> MultiValueMap<String, Part>.getAsType(key: String): T =
+        T::class.java.cast(getFirst(key))
             ?: throw IllegalArgumentException(
                 buildLogMessage(
                     "Failed to retrieve and cast provided argument",

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreObject.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/StoreObject.kt
@@ -4,12 +4,14 @@ import io.provenance.api.domain.objectStore.ObjectStore
 import io.provenance.api.domain.usecase.AbstractUseCase
 import io.provenance.api.domain.usecase.common.originator.EntityManager
 import io.provenance.api.domain.usecase.objectStore.store.models.StoreObjectRequest
+import io.provenance.api.domain.usecase.objectStore.store.models.StoreObjectStreamRequest
 import io.provenance.api.frameworks.config.ObjectStoreProperties
 import io.provenance.api.frameworks.config.ProvenanceProperties
 import io.provenance.api.models.eos.store.StoreProtoResponse
 import io.provenance.scope.encryption.util.toJavaPublicKey
 import io.provenance.scope.objectstore.client.OsClient
 import java.net.URI
+import kotlin.io.path.inputStream
 import org.springframework.stereotype.Component
 import tech.figure.objectstore.gateway.client.ClientConfig
 import tech.figure.objectstore.gateway.client.GatewayClient
@@ -37,6 +39,29 @@ class StoreObject(
                 additionalAudiences.map { it.encryptionKey.toJavaPublicKey() }.toSet(),
                 args.type
             )
+        }
+    }
+
+    /*
+     * Streaming counterpart to execute(StoreObjectRequest). Uploads directly from the temp file on
+     * disk via an InputStream so a large raw payload never has to be held in memory as a ByteArray.
+     * Only ever uses the direct OsClient -- the gateway client cannot stream -- so callers must
+     * restrict this path to non-gateway, raw-byte stores.
+     */
+    suspend fun executeStreaming(args: StoreObjectStreamRequest): StoreProtoResponse {
+        val additionalAudiences = entityManager.hydrateKeys(args.permissions)
+
+        OsClient(URI.create(args.objectStoreUrl), objectStoreProperties.timeoutMs).use { client ->
+            args.source.inputStream().use { stream ->
+                return objectStore.store(
+                    client,
+                    stream,
+                    args.contentLength,
+                    args.keyRef,
+                    additionalAudiences.map { it.encryptionKey.toJavaPublicKey() }.toSet(),
+                    args.type
+                )
+            }
         }
     }
 }

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreFileRequestWrapper.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreFileRequestWrapper.kt
@@ -4,10 +4,17 @@ import io.provenance.api.models.entity.Entity
 import java.util.UUID
 import org.springframework.http.codec.multipart.FilePart
 import org.springframework.http.codec.multipart.Part
+import org.springframework.util.MultiValueMap
 
 data class StoreFileRequestWrapper(
     val entity: Entity,
-    val request: Map<String, Part>,
+    /*
+     * The full multipart map (all values per field name), not the single-value view. Retaining every
+     * part -- including duplicates that share a field name -- is required so cleanup can delete the
+     * temp file backing each spilled FilePart. toSingleValueMap() keeps only the first part per name,
+     * which silently dropped (and therefore leaked the temp files of) any duplicate-named parts.
+     */
+    val request: MultiValueMap<String, Part>,
     val useObjectStoreGateway: Boolean = false
 )
 

--- a/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreObjectStreamRequest.kt
+++ b/service/src/main/kotlin/io/provenance/api/domain/usecase/objectStore/store/models/StoreObjectStreamRequest.kt
@@ -1,0 +1,23 @@
+package io.provenance.api.domain.usecase.objectStore.store.models
+
+import io.provenance.api.models.account.AccountInfo
+import io.provenance.api.models.p8e.PermissionInfo
+import io.provenance.scope.encryption.model.KeyRef
+import java.nio.file.Path
+
+/**
+ * Request to store the raw contents of a file that has already been spilled to a temporary file on
+ * disk, streaming it to the object store instead of loading it into memory.
+ *
+ * This is the memory-safe counterpart to [StoreObjectRequest] and is only valid for the direct
+ * object-store client (never the gateway). The referenced [source] file is owned by the caller.
+ */
+data class StoreObjectStreamRequest(
+    val source: Path,
+    val contentLength: Long,
+    val type: String?,
+    val objectStoreUrl: String,
+    val keyRef: KeyRef,
+    val permissions: PermissionInfo? = null,
+    val account: AccountInfo = AccountInfo(),
+)

--- a/service/src/main/kotlin/io/provenance/api/frameworks/config/AppConfig.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/config/AppConfig.kt
@@ -6,8 +6,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
+@EnableScheduling
 @EnableConfigurationProperties(
     value = [
         ServiceProps::class,

--- a/service/src/main/kotlin/io/provenance/api/frameworks/objectStore/ObjectStoreService.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/objectStore/ObjectStoreService.kt
@@ -9,6 +9,7 @@ import io.provenance.scope.encryption.domain.inputstream.DIMEInputStream
 import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.objectstore.client.OsClient
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.security.PublicKey
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -66,6 +67,34 @@ class ObjectStoreService(
                 ).toModel()
             }
             else -> throw IllegalArgumentException("Unsupported client type while storing object!")
+        }
+
+    /*
+     * Streaming store: the OsClient exposes an InputStream overload with an explicit content length,
+     * letting us upload directly from the temp file on disk without ever materializing the full
+     * payload as a ByteArray on the heap. The gateway client only accepts a byte[], so it cannot be
+     * streamed and is intentionally rejected here -- callers must gate this path on a direct client.
+     */
+    override fun <T> store(
+        client: T,
+        message: InputStream,
+        contentLength: Long,
+        keyRef: KeyRef,
+        additionalAudiences: Set<PublicKey>,
+        type: String?
+    ): StoreProtoResponse =
+        when (client) {
+            is OsClient -> {
+                client.put(
+                    message,
+                    keyRef.publicKey,
+                    keyRef.signer(),
+                    contentLength,
+                    additionalAudiences,
+                    type?.let { mapOf("type" to type) } ?: mapOf()
+                ).get(objectStoreProperties.timeoutMs, TimeUnit.MILLISECONDS).toModel()
+            }
+            else -> throw IllegalArgumentException("Streaming store is only supported for the direct object-store client!")
         }
 
     private fun decodeBase64(string: String): ByteArray =

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
@@ -2,6 +2,7 @@ package io.provenance.api.frameworks.web.config
 
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.nio.file.Files
@@ -31,6 +32,9 @@ import kotlin.io.path.name
  * [maxAge]. The age threshold must be comfortably larger than the longest legitimate in-flight
  * upload so that a file currently being written is never deleted out from under an active request.
  *
+ * Disabled by default; enable with `multipart.sweep.enabled=true`
+ * (env: `MULTIPART_SWEEP_ENABLED=true`).
+ *
  * This is deliberately *not* redundant with the two other cleanup paths, both of which only cover
  * requests that actually reach a handler: Spring's `cleanupMultipart` (which short-circuits while
  * `multipartRead` is false) and this service's own per-request `FilePart.delete()` in
@@ -39,6 +43,7 @@ import kotlin.io.path.name
  * a case WebFlux provides no built-in reaper or `deleteOnExit` fallback for.
  */
 @Component
+@ConditionalOnProperty(name = ["multipart.sweep.enabled"], havingValue = "true", matchIfMissing = false)
 class MultipartTempFileSweeper(
     @Value("\${multipart.temp.max-age-ms:7200000}")
     private val maxAgeMs: Long,

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
@@ -30,6 +30,13 @@ import kotlin.io.path.name
  * `spring-multipart-*` working directories and removes any regular file older than
  * [maxAge]. The age threshold must be comfortably larger than the longest legitimate in-flight
  * upload so that a file currently being written is never deleted out from under an active request.
+ *
+ * This is deliberately *not* redundant with the two other cleanup paths, both of which only cover
+ * requests that actually reach a handler: Spring's `cleanupMultipart` (which short-circuits while
+ * `multipartRead` is false) and this service's own per-request `FilePart.delete()` in
+ * `StoreFile` (which never runs because the handler is never invoked for an aborted parse). The
+ * sweeper is the only mechanism that reclaims files orphaned before the request lifecycle completes,
+ * a case WebFlux provides no built-in reaper or `deleteOnExit` fallback for.
  */
 @Component
 class MultipartTempFileSweeper(

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeper.kt
@@ -1,0 +1,119 @@
+package io.provenance.api.frameworks.web.config
+
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import kotlin.io.path.getLastModifiedTime
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
+
+/**
+ * Periodically deletes stale multipart temporary files that the reactive multipart reader spilled to
+ * disk but that were never removed by [org.springframework.http.codec.multipart.FilePart.delete].
+ *
+ * This is required because Spring WebFlux only runs its own multipart cleanup
+ * ([org.springframework.web.server.adapter.HttpWebHandlerAdapter] ->
+ * `DefaultServerWebExchange.cleanupMultipart`) once the entire multipart body has been collected and
+ * the `multipartRead` flag has been set. When a large upload is aborted (or otherwise errors) part
+ * way through parsing, the temp file has already been written to disk — yet neither the framework
+ * cleanup nor any application handler ever runs for that part, so the file is orphaned for the whole
+ * lifetime of the pod. Left unchecked, this fills the pod's disk with hundreds of GB of
+ * `*.multipart` files.
+ *
+ * The sweeper scans the JVM temp directory ([java.io.tmpdir]) for the reader's
+ * `spring-multipart-*` working directories and removes any regular file older than
+ * [maxAge]. The age threshold must be comfortably larger than the longest legitimate in-flight
+ * upload so that a file currently being written is never deleted out from under an active request.
+ */
+@Component
+class MultipartTempFileSweeper(
+    @Value("\${multipart.temp.max-age-ms:7200000}")
+    private val maxAgeMs: Long,
+    @Value("\${java.io.tmpdir:/tmp}")
+    private val tempDirectory: String,
+) {
+    private val log = KotlinLogging.logger {}
+
+    private val maxAge: Duration = Duration.ofMillis(maxAgeMs)
+
+    /**
+     * Deletes stale spilled multipart files. Scheduled with a fixed delay so runs never overlap.
+     */
+    @Scheduled(
+        fixedDelayString = "\${multipart.sweep.interval-ms:1800000}",
+        initialDelayString = "\${multipart.sweep.interval-ms:1800000}",
+    )
+    fun sweep() {
+        val root = Path.of(tempDirectory)
+        if (!root.isDirectory()) {
+            log.warn { "Multipart temp sweep skipped; directory does not exist [tempDirectory=$tempDirectory]" }
+            return
+        }
+
+        val cutoff = Instant.now().minus(maxAge)
+        var deleted = 0L
+        var reclaimedBytes = 0L
+
+        runCatching {
+            Files.newDirectoryStream(root, "spring-multipart-*").use { multipartDirs ->
+                multipartDirs.forEach { dir ->
+                    if (dir.isDirectory()) {
+                        val (count, bytes) = sweepDirectory(dir, cutoff)
+                        deleted += count
+                        reclaimedBytes += bytes
+                    }
+                }
+            }
+        }.onFailure { error ->
+            log.error(error) { "Failed to enumerate multipart temp directories under [tempDirectory=$tempDirectory]" }
+        }
+
+        if (deleted > 0) {
+            log.info {
+                "Multipart temp sweep removed [files=$deleted, reclaimedBytes=$reclaimedBytes] " +
+                    "older than [maxAge=$maxAge]"
+            }
+        }
+    }
+
+    private fun sweepDirectory(dir: Path, cutoff: Instant): Pair<Long, Long> {
+        var count = 0L
+        var bytes = 0L
+        runCatching {
+            Files.newDirectoryStream(dir).use { entries ->
+                entries.forEach { file ->
+                    if (file.isStaleMultipartFile(cutoff)) {
+                        val size = runCatching { Files.size(file) }.getOrDefault(0L)
+                        val removed = runCatching { Files.deleteIfExists(file) }
+                            .getOrElse { error ->
+                                logDeleteFailure(file, error)
+                                false
+                            }
+                        if (removed) {
+                            count++
+                            bytes += size
+                        }
+                    }
+                }
+            }
+        }.onFailure { error ->
+            log.error(error) { "Failed to sweep multipart temp directory [dir=${dir.name}]" }
+        }
+        return count to bytes
+    }
+
+    private fun Path.isStaleMultipartFile(cutoff: Instant): Boolean =
+        isRegularFile() &&
+            name.endsWith(".multipart") &&
+            runCatching { getLastModifiedTime().toInstant().isBefore(cutoff) }.getOrDefault(false)
+
+    private fun logDeleteFailure(file: Path, error: Throwable) {
+        log.warn(error) { "Failed to delete stale multipart temp file [file=${file.name}]" }
+    }
+}

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/config/WebConfig.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/config/WebConfig.kt
@@ -23,6 +23,15 @@ class WebConfig(
      */
     @Value("\${multipart.max-in-memory-size:262144}")
     private val multipartMaxInMemorySize: Int,
+    /*
+     * The maximum number of bytes a single multipart part may occupy on disk before the reader
+     * rejects the request. This is a safety ceiling to guard against pathological / runaway uploads
+     * consuming unbounded disk; it is deliberately set well above the largest legitimate upload
+     * (~1 GB) rather than being a tight limit. Configurable via the MULTIPART_MAX_DISK_USAGE_PER_PART
+     * environment variable; defaults to 2 GiB. A negative value disables the limit (Spring default).
+     */
+    @Value("\${multipart.max-disk-usage-per-part:2147483648}")
+    private val multipartMaxDiskUsagePerPart: Long,
 ) : WebFluxConfigurer {
 
     override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
@@ -33,6 +42,7 @@ class WebConfig(
         val partReader = DefaultPartHttpMessageReader()
         partReader.setMaxHeadersSize(16 * 1024 * 1024)
         partReader.setMaxInMemorySize(multipartMaxInMemorySize)
+        partReader.setMaxDiskUsagePerPart(multipartMaxDiskUsagePerPart)
         val multipartReader = MultipartHttpMessageReader(partReader)
         configurer.defaultCodecs().multipartReader(multipartReader)
     }

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/external/objectStore/ObjectStoreHandler.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/external/objectStore/ObjectStoreHandler.kt
@@ -65,7 +65,7 @@ class ObjectStoreHandler(
         storeFile.execute(
             StoreFileRequestWrapper(
                 req.getEntity(),
-                req.awaitMultipartData().toSingleValueMap(),
+                req.awaitMultipartData(),
             )
         )
     }.foldToServerResponse()
@@ -74,7 +74,7 @@ class ObjectStoreHandler(
         storeFile.execute(
             StoreFileRequestWrapper(
                 req.getEntity(),
-                req.awaitMultipartData().toSingleValueMap(),
+                req.awaitMultipartData(),
                 true
             )
         ).toModel()

--- a/service/src/main/kotlin/io/provenance/api/frameworks/web/internal/objectStore/InternalObjectStoreHandler.kt
+++ b/service/src/main/kotlin/io/provenance/api/frameworks/web/internal/objectStore/InternalObjectStoreHandler.kt
@@ -40,7 +40,7 @@ class InternalObjectStoreHandler(
         storeFile.execute(
             StoreFileRequestWrapper(
                 req.getEntity(),
-                req.awaitMultipartData().toSingleValueMap()
+                req.awaitMultipartData()
             )
         )
     }.foldToServerResponse()
@@ -85,7 +85,7 @@ class InternalObjectStoreHandler(
         storeFile.execute(
             StoreFileRequestWrapper(
                 req.getEntity(),
-                req.awaitMultipartData().toSingleValueMap(),
+                req.awaitMultipartData(),
                 true
             )
         ).toModel()

--- a/service/src/main/kotlin/io/provenance/api/util/MultiPartExtensions.kt
+++ b/service/src/main/kotlin/io/provenance/api/util/MultiPartExtensions.kt
@@ -4,6 +4,7 @@ import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.http.codec.multipart.FilePart
 import reactor.core.publisher.Mono
+import java.nio.file.Path
 
 /**
  * Reads the full contents of this [FilePart] into a [ByteArray].
@@ -25,3 +26,18 @@ fun FilePart.awaitAllBytes(): Mono<ByteArray> =
             DataBufferUtils.release(dataBuffer)
         }
     }
+
+/**
+ * Transfers the full contents of this [FilePart] to [destination], returning it once the write
+ * completes.
+ *
+ * When the reactive multipart reader has already spilled this part to a temporary file, this is
+ * effectively a file move; when the part is still in memory it is written out. Either way the
+ * payload is never materialized as a single [ByteArray] on the heap, which is what makes this the
+ * memory-safe path for very large uploads.
+ *
+ * NOTE: callers remain responsible for invoking [FilePart.delete] on the original part and for
+ * removing [destination] once they are done with it.
+ */
+fun FilePart.transferToPath(destination: Path): Mono<Path> =
+    this.transferTo(destination).thenReturn(destination)

--- a/service/src/main/resources/application-container.properties
+++ b/service/src/main/resources/application-container.properties
@@ -8,6 +8,12 @@ object-store.timeoutMs=${OBJECT_STORE_TIMEOUT_MS:60000}
 vault.address=${VAULT_ADDRESS}
 vault.tokenPath=${VAULT_TOKEN_PATH:vault/secrets/token}
 
+# Multipart temp-file handling
+multipart.max-in-memory-size=${MULTIPART_MAX_IN_MEMORY_SIZE:262144}
+multipart.max-disk-usage-per-part=${MULTIPART_MAX_DISK_USAGE_PER_PART:2147483648}
+multipart.sweep.interval-ms=${MULTIPART_SWEEP_INTERVAL_MS:1800000}
+multipart.temp.max-age-ms=${MULTIPART_TEMP_MAX_AGE_MS:7200000}
+
 p8e.mainnet=${IS_MAIN_NET:false}
 p8e.members[0].id=${DART_UUID}
 p8e.members[0].name=DART

--- a/service/src/main/resources/application-container.properties
+++ b/service/src/main/resources/application-container.properties
@@ -11,6 +11,7 @@ vault.tokenPath=${VAULT_TOKEN_PATH:vault/secrets/token}
 # Multipart temp-file handling
 multipart.max-in-memory-size=${MULTIPART_MAX_IN_MEMORY_SIZE:262144}
 multipart.max-disk-usage-per-part=${MULTIPART_MAX_DISK_USAGE_PER_PART:2147483648}
+multipart.sweep.enabled=${MULTIPART_SWEEP_ENABLED:true}
 multipart.sweep.interval-ms=${MULTIPART_SWEEP_INTERVAL_MS:1800000}
 multipart.temp.max-age-ms=${MULTIPART_TEMP_MAX_AGE_MS:7200000}
 

--- a/service/src/test/kotlin/io/provenance/api/domain/usecase/objectstore/StoreFileCleanupTest.kt
+++ b/service/src/test/kotlin/io/provenance/api/domain/usecase/objectstore/StoreFileCleanupTest.kt
@@ -1,0 +1,64 @@
+package io.provenance.api.domain.usecase.objectstore
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.provenance.api.domain.usecase.common.originator.EntityManager
+import io.provenance.api.domain.usecase.objectStore.store.StoreFile
+import io.provenance.api.domain.usecase.objectStore.store.StoreObject
+import io.provenance.api.domain.usecase.objectStore.store.models.StoreFileRequestWrapper
+import io.provenance.api.models.entity.MemberUUID
+import org.springframework.http.codec.multipart.FilePart
+import org.springframework.http.codec.multipart.Part
+import org.springframework.util.LinkedMultiValueMap
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+class StoreFileCleanupTest : FunSpec({
+
+    val entityManager = mockk<EntityManager>()
+    val storeObject = mockk<StoreObject>(relaxed = true)
+    val storeFile = StoreFile(entityManager, storeObject)
+
+    fun mockFilePart(): FilePart = mockk<FilePart>(relaxed = true).also {
+        every { it.delete() } returns Mono.empty()
+    }
+
+    test("deletes every FilePart including duplicates under the same field name on a failed request") {
+        val firstFile = mockFilePart()
+        val duplicateFile = mockFilePart()
+
+        // Two parts share the "file" field name; toSingleValueMap() would have dropped the second.
+        val request = LinkedMultiValueMap<String, Part>().apply {
+            add("file", firstFile)
+            add("file", duplicateFile)
+        }
+
+        // No "id" field -> getParams() throws before any store happens, exercising the finally block.
+        shouldThrow<IllegalArgumentException> {
+            storeFile.execute(StoreFileRequestWrapper(MemberUUID(UUID.randomUUID()), request))
+        }
+
+        verify(exactly = 1) { firstFile.delete() }
+        verify(exactly = 1) { duplicateFile.delete() }
+    }
+
+    test("deletes FileParts spread across multiple field names") {
+        val fileA = mockFilePart()
+        val fileB = mockFilePart()
+
+        val request = LinkedMultiValueMap<String, Part>().apply {
+            add("file", fileA)
+            add("attachment", fileB)
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            storeFile.execute(StoreFileRequestWrapper(MemberUUID(UUID.randomUUID()), request))
+        }
+
+        verify(exactly = 1) { fileA.delete() }
+        verify(exactly = 1) { fileB.delete() }
+    }
+})

--- a/service/src/test/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeperTest.kt
+++ b/service/src/test/kotlin/io/provenance/api/frameworks/web/config/MultipartTempFileSweeperTest.kt
@@ -1,0 +1,97 @@
+package io.provenance.api.frameworks.web.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+import kotlin.io.path.exists
+
+class MultipartTempFileSweeperTest : FunSpec({
+
+    lateinit var tempRoot: Path
+
+    fun ageOf(path: Path, age: java.time.Duration) {
+        Files.setLastModifiedTime(path, FileTime.from(Instant.now().minus(age)))
+    }
+
+    beforeTest {
+        tempRoot = Files.createTempDirectory("sweeper-test-")
+    }
+
+    afterTest {
+        // Best-effort recursive cleanup of the test scratch directory.
+        Files.walk(tempRoot).sorted(Comparator.reverseOrder()).forEach { runCatching { Files.deleteIfExists(it) } }
+    }
+
+    test("deletes stale .multipart files inside spring-multipart-* directories") {
+        val readerDir = Files.createDirectory(tempRoot.resolve("spring-multipart-1234567890"))
+        val stale = Files.createFile(readerDir.resolve("111.multipart"))
+        ageOf(stale, java.time.Duration.ofHours(3))
+
+        val sweeper = MultipartTempFileSweeper(
+            maxAgeMs = java.time.Duration.ofHours(2).toMillis(),
+            tempDirectory = tempRoot.toString(),
+        )
+
+        sweeper.sweep()
+
+        stale.exists() shouldBe false
+    }
+
+    test("keeps fresh .multipart files younger than max age") {
+        val readerDir = Files.createDirectory(tempRoot.resolve("spring-multipart-2222222222"))
+        val fresh = Files.createFile(readerDir.resolve("222.multipart"))
+        ageOf(fresh, java.time.Duration.ofMinutes(5))
+
+        val sweeper = MultipartTempFileSweeper(
+            maxAgeMs = java.time.Duration.ofHours(2).toMillis(),
+            tempDirectory = tempRoot.toString(),
+        )
+
+        sweeper.sweep()
+
+        fresh.exists() shouldBe true
+    }
+
+    test("ignores stale files that are not .multipart") {
+        val readerDir = Files.createDirectory(tempRoot.resolve("spring-multipart-3333333333"))
+        val other = Files.createFile(readerDir.resolve("notes.txt"))
+        ageOf(other, java.time.Duration.ofHours(3))
+
+        val sweeper = MultipartTempFileSweeper(
+            maxAgeMs = java.time.Duration.ofHours(2).toMillis(),
+            tempDirectory = tempRoot.toString(),
+        )
+
+        sweeper.sweep()
+
+        other.exists() shouldBe true
+    }
+
+    test("ignores stale .multipart files outside spring-multipart-* directories") {
+        val unrelatedDir = Files.createDirectory(tempRoot.resolve("datadog"))
+        val stray = Files.createFile(unrelatedDir.resolve("444.multipart"))
+        ageOf(stray, java.time.Duration.ofHours(3))
+
+        val sweeper = MultipartTempFileSweeper(
+            maxAgeMs = java.time.Duration.ofHours(2).toMillis(),
+            tempDirectory = tempRoot.toString(),
+        )
+
+        sweeper.sweep()
+
+        stray.exists() shouldBe true
+    }
+
+    test("does not fail when temp directory does not exist") {
+        val sweeper = MultipartTempFileSweeper(
+            maxAgeMs = java.time.Duration.ofHours(2).toMillis(),
+            tempDirectory = tempRoot.resolve("does-not-exist").toString(),
+        )
+
+        // Should simply log and return without throwing.
+        sweeper.sweep()
+    }
+})


### PR DESCRIPTION
## Context

#147 has proven insufficient in addressing the removal of temporary files. Opting for a more aggressive approach to cover more possible avenues of dropped files:

- For interrupted requests, delete the file via cronjob
- For happy path requests, stream the file and explicitly clean it up ourselves


The addition of streaming will also reduce memory usage.

## Changes

- Ensure ALL parts of a multi-part form request are cleaned up (even if we typically don't get duplicate keys)
- Allow raw byte object store requests not sent to a gateway to be streamed
- Add scheduled job to manually clean up leftover multipart files, since we can never guarantee that they get cleaned up in the event of an aborted request