### PR TITLE
chore[sc-534571]: migrate Sonatype publishing to Central Portal staging API

### DIFF
--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,5 +1,5 @@
 object RepositoryLocations {
     const val JitPack = "https://javadoc.jitpack.io"
-    const val Sonatype = "https://s01.oss.sonatype.org/service/local/"
-    const val SonatypeSnapshot = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    const val Sonatype = "https://ossrh-staging-api.central.sonatype.com/service/local/"
+    const val SonatypeSnapshot = "https://central.sonatype.com/repository/maven-snapshots/"
 }


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Publishing to Maven Central is failing with HTTP 402 when creating a Sonatype staging repository against the legacy OSSRH host `s01.oss.sonatype.org` (see [failed run](https://github.com/provenance-io/p8e-cee-api/actions/runs/30586825099/job/91020063136)).
This matches the OSSRH end-of-life issue Provenance hit earlier ([provenance-io/provenance#2398](https://github.com/provenance-io/provenance/issues/2398)), fixed by updating endpoints in [provenance-io/provenance#2415](https://github.com/provenance-io/provenance/pull/2415).

closes: #148

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Tagged PR with **exactly one of** `patch`, `minor`, or `major`, adhering to [semantic versioning](https://semver.org/)
- [x] Tagged PR with one or more of `feature`, `enhancement`, `fix`/`bugfix`, `chore`, `dependencies`, & `docs`, as applicable to the scope of the PR
- [x] Acknowledge that by merging my changes to `main`, they are ready to be included in the next release, and otherwise would ask for a prerelease to be created against my branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Wrote unit and integration tests as applicable to the scope of the PR
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Reviewed `Test Results` in the comment section below once CI passes
